### PR TITLE
feat: track code coverage with codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+    patch: off

--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths:
       - "**/*.ts"
+  push:
+    branches:
+      - main
 
 jobs:
   bun-test:
@@ -15,4 +18,11 @@ jobs:
       - run: bun install
 
       - name: Run tests
-        run: bun test
+        run: bun test --coverage-reporter lcov
+
+      - uses: codecov/codecov-action@v4.5.0
+        with:
+          slug: Topsort/topsort.js
+          files: coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unittest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-node_modules/
+coverage/
 dist/
+node_modules/


### PR DESCRIPTION
By running tests in a PR branch and in `main`, we send coverage reports to codecov that can help us from merging a PR that takes us away from 100% coverage.