### PR TITLE
fix: export module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,19 +9,26 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "default": "./dist/index.mjs",
+        "types": "./dist/index.d.mts"
+      },
+      "require": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      }
     }
   },
+  "types": "./dist/index.d.ts",
   "files": [
+    "CHANGELOG.md",
+    "LICENSE",
+    "README.md",
+    "dist/index.d.mts",
+    "dist/index.d.ts",
     "dist/index.js",
     "dist/index.mjs",
-    "dist/*.d.ts",
-    "package.json",
-    "LICENSE",
-    "CHANGELOG.md",
-    "README.md"
+    "package.json"
   ],
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
Support exporting both module and require types. They are the same right not but might diverge in the future.