### PR TITLE
fix: don't enforce coverage locally

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,2 @@
 [test]
 coverage = true
-coverageThreshold = 1.0


### PR DESCRIPTION
This enforcement would otherwise create an annoying loop of failed commits, meaning you can't do small and incremental work.