### PR TITLE
fix(docs): changing browser installation command to use bunx

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,15 +98,22 @@ bun run test
 ### E2E Tests
 
 By default, the application is set to serve a web browser in the port `8080` for Playwright. If this port is already being used on your local machine, make sure you change the port in your `.env`.`SERVER_PORT`.
+
+First, make sure you have all the dependencies installed:
+
+```bash
+bun install
+```
+
 To run the end-to-end tests, make sure you have installed the browsers supported by playwright by running this command:
 
 ```bash
-npx playwright install
+bunx playwright install
 ```
 
 Please refer to [Playwright Documentation](https://playwright.dev/docs/browsers) for details.
 
-Then, also make sure you have the latest bundled files before running it. Use the following commands:
+Then, make sure you have the latest bundled files before running it. Use the following commands:
 
 ```bash
 bun run build


### PR DESCRIPTION
This PR changes the browser installation for Playwright from `npx` to `bunx`