### PR TITLE
feat: adding `retry` to error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository holds the official Topsort javascript client library. This proje
 - [Usage](#usage)
   - [Creating an Auction](#auctions)
   - [Reporting an Event](#events)
+    - [Retryable Errors](#retryable-errors)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -151,7 +152,8 @@ reportEvent(config, event)
 200:
 ```json
 {
-    "ok": true
+  "ok": true,
+  "retry": false
 }
 ```
 400:
@@ -162,10 +164,21 @@ reportEvent(config, event)
   "body": {
     "errCode": "bad_request",
     "docUrl": "https://docs.topsort.com/reference/errors",
-    "message": "The request could not be parsed.",
-  },
+    "message": "The request could not be parsed."
+  }
 }
 ```
+429:
+```json
+{
+  "ok": false,
+  "retry": true
+}
+```
+
+#### Retryable Errors
+
+The `reportEvent` function returns `"retry": true` if the response status code is `429` or any `5xx`. This enables you to identify when it’s appropriate to retry the function call.
 
 ## Contributing
 

--- a/e2e/auctions.test.ts
+++ b/e2e/auctions.test.ts
@@ -58,7 +58,12 @@ test.describe("Create Auction via Topsort SDK", () => {
   });
 
   test("should fail to call with missing apiKey", async ({ page }) => {
-    const expectedError = { status: 401, retry: false, statusText: "API Key is required.", body: {} };
+    const expectedError = {
+      status: 401,
+      retry: false,
+      statusText: "API Key is required.",
+      body: {},
+    };
     await page.goto(playwrightConstants.host);
     const result = await page.evaluate(() => {
       const config = {

--- a/e2e/auctions.test.ts
+++ b/e2e/auctions.test.ts
@@ -58,7 +58,7 @@ test.describe("Create Auction via Topsort SDK", () => {
   });
 
   test("should fail to call with missing apiKey", async ({ page }) => {
-    const expectedError = { status: 401, statusText: "API Key is required.", body: {} };
+    const expectedError = { status: 401, retry: false, statusText: "API Key is required.", body: {} };
     await page.goto(playwrightConstants.host);
     const result = await page.evaluate(() => {
       const config = {

--- a/e2e/events.test.ts
+++ b/e2e/events.test.ts
@@ -6,7 +6,7 @@ test.describe("Report Events via Topsort SDK", () => {
   test("should report an event successfully", async ({ page }) => {
     const mockAPIResponse = {
       ok: true,
-      retry: false, 
+      retry: false,
     };
 
     await page.route(`${baseURL}/${apis.events}`, async (route) => {
@@ -45,7 +45,12 @@ test.describe("Report Events via Topsort SDK", () => {
   });
 
   test("should fail to call with missing apiKey", async ({ page }) => {
-    const expectedError = { status: 401, retry: false, statusText: "API Key is required.", body: {} };
+    const expectedError = {
+      status: 401,
+      retry: false,
+      statusText: "API Key is required.",
+      body: {},
+    };
     await page.goto(playwrightConstants.host);
     const result = await page.evaluate(() => {
       const config = {

--- a/e2e/events.test.ts
+++ b/e2e/events.test.ts
@@ -3,9 +3,10 @@ import { apis, baseURL } from "../src/constants/apis.constant";
 import { playwrightConstants } from "./config";
 
 test.describe("Report Events via Topsort SDK", () => {
-  test("should report an successfully", async ({ page }) => {
+  test("should report an event successfully", async ({ page }) => {
     const mockAPIResponse = {
       ok: true,
+      retry: false, 
     };
 
     await page.route(`${baseURL}/${apis.events}`, async (route) => {
@@ -44,7 +45,7 @@ test.describe("Report Events via Topsort SDK", () => {
   });
 
   test("should fail to call with missing apiKey", async ({ page }) => {
-    const expectedError = { status: 401, statusText: "API Key is required.", body: {} };
+    const expectedError = { status: 401, retry: false, statusText: "API Key is required.", body: {} };
     await page.goto(playwrightConstants.host);
     const result = await page.evaluate(() => {
       const config = {

--- a/src/constants/apis.constant.ts
+++ b/src/constants/apis.constant.ts
@@ -4,5 +4,3 @@ export const apis = {
   auctions: "v2/auctions",
   events: "v2/events",
 };
-
-export const retryableStatusCodes = [429, 500, 502, 503, 504];

--- a/src/constants/apis.constant.ts
+++ b/src/constants/apis.constant.ts
@@ -4,3 +4,5 @@ export const apis = {
   auctions: "v2/auctions",
   events: "v2/events",
 };
+
+export const retryableStatusCodes = [429, 500, 502, 503, 504];

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,5 +1,5 @@
 import { version } from "../../package.json";
-import { baseURL } from "../constants/apis.constant";
+import { baseURL, retryableStatusCodes } from "../constants/apis.constant";
 import type { Config } from "../types/shared";
 import AppError from "./app-error";
 
@@ -20,7 +20,8 @@ class APIClient {
     }
 
     if (!response.ok) {
-      throw new AppError(response.status, response.statusText, data);
+      const retry = retryableStatusCodes.includes(response.status);
+      throw new AppError(response.status, response.statusText, data, retry);
     }
 
     return data;

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,5 +1,5 @@
 import { version } from "../../package.json";
-import { baseURL, retryableStatusCodes } from "../constants/apis.constant";
+import { baseURL } from "../constants/apis.constant";
 import type { Config } from "../types/shared";
 import AppError from "./app-error";
 
@@ -20,7 +20,7 @@ class APIClient {
     }
 
     if (!response.ok) {
-      const retry = retryableStatusCodes.includes(response.status);
+      const retry = response.status === 429 || response.status >= 500;
       throw new AppError(response.status, response.statusText, data, retry);
     }
 

--- a/src/lib/app-error.ts
+++ b/src/lib/app-error.ts
@@ -2,11 +2,13 @@ class AppError {
   public readonly status: number; //change later to http status code
   public readonly statusText: string;
   public readonly body: unknown;
+  public readonly retry: boolean;
 
-  constructor(status: number, statusText: string, body: unknown) {
+  constructor(status: number, statusText: string, body: unknown, retry = false) {
     this.status = status;
     this.statusText = statusText;
     this.body = body;
+    this.retry = retry;
   }
 }
 

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -45,3 +45,8 @@ export interface TopsortEvent {
   clicks?: Click[];
   purchases?: Purchase[];
 }
+
+export interface EventResult {
+  ok: boolean;
+  retry: boolean;
+}

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -18,6 +18,7 @@ describe("createAuction", () => {
     returnStatus(401, `${baseURL}/${apis.auctions}`);
     expect(createAuction({ apiKey: "apiKey" }, {} as TopsortAuction)).rejects.toEqual({
       status: 401,
+      retry: false,
       statusText: "Unauthorized",
       body: {},
     });
@@ -27,6 +28,7 @@ describe("createAuction", () => {
     returnStatus(429, `${baseURL}/${apis.auctions}`);
     expect(createAuction({ apiKey: "apiKey" }, {} as TopsortAuction)).rejects.toEqual({
       status: 429,
+      retry: true,
       statusText: "Too Many Requests",
       body: {},
     });
@@ -36,6 +38,7 @@ describe("createAuction", () => {
     returnStatus(500, `${baseURL}/${apis.auctions}`);
     expect(createAuction({ apiKey: "apiKey" }, {} as TopsortAuction)).rejects.toEqual({
       status: 500,
+      retry: true,
       statusText: "Internal Server Error",
       body: {},
     });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -12,6 +12,7 @@ describe("reportEvent", () => {
     returnStatus(401, `${baseURL}/${apis.events}`);
     expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).rejects.toEqual({
       status: 401,
+      retry: false,
       statusText: "Unauthorized",
       body: {},
     });
@@ -19,19 +20,17 @@ describe("reportEvent", () => {
 
   it("should handle retryable error", async () => {
     returnStatus(429, `${baseURL}/${apis.events}`);
-    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).rejects.toEqual({
-      status: 429,
-      statusText: "Too Many Requests",
-      body: {},
+    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).resolves.toEqual({
+      ok: false,
+      retry: true,
     });
   });
 
   it("should handle server error", async () => {
     returnStatus(500, `${baseURL}/${apis.events}`);
-    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).rejects.toEqual({
-      status: 500,
-      statusText: "Internal Server Error",
-      body: {},
+    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).resolves.toEqual({
+      ok: false,
+      retry: true,
     });
   });
 
@@ -45,7 +44,7 @@ describe("reportEvent", () => {
         },
         {} as TopsortEvent,
       ),
-    ).resolves.toEqual({ ok: true });
+    ).resolves.toEqual({ ok: true, retry: false });
   });
 
   it("should handle fetch error", async () => {


### PR DESCRIPTION
This PR is part of integrating Topsort.js with Analytics.js

This PR allows the `AppError` class to return the `retry` property.
Also, added as part of the `reportEvent` function a catch to return
the `retry` value from the error caught.