### PR TITLE
feat(test): add e2e test for timeout on config

### DIFF
--- a/e2e/auctions.test.ts
+++ b/e2e/auctions.test.ts
@@ -47,9 +47,6 @@ test.describe("Create Auction via Topsort SDK", () => {
           },
         ],
       };
-      if (typeof window.sdk.createAuction === "undefined") {
-        throw new Error("Global function `createAuction` is not available.");
-      }
 
       return window.sdk.createAuction(config, auctionDetails);
     });
@@ -88,9 +85,6 @@ test.describe("Create Auction via Topsort SDK", () => {
           },
         ],
       };
-      if (typeof window.sdk.createAuction === "undefined") {
-        throw new Error("Global function `createAuction` is not available.");
-      }
 
       return window.sdk.createAuction(config, auctionDetails);
     });
@@ -110,7 +104,7 @@ test.describe("Create Auction via Topsort SDK", () => {
     };
 
     await page.route(`${baseURL}/${apis.auctions}`, async (route) => {
-      await delay(2000);
+      await delay(100);
       await route.fulfill({ json: mockAPIResponse });
     });
 
@@ -119,7 +113,7 @@ test.describe("Create Auction via Topsort SDK", () => {
       const startTime = Date.now();
       const config = {
         apiKey: "rando-api-key",
-        timeOut: 2000,
+        timeOut: 100,
       };
 
       const auctionDetails = {
@@ -132,9 +126,6 @@ test.describe("Create Auction via Topsort SDK", () => {
           },
         ],
       };
-      if (typeof window.sdk.createAuction === "undefined") {
-        throw new Error("Global function `createAuction` is not available.");
-      }
 
       const createAuctionResult = await window.sdk.createAuction(config, auctionDetails);
       const endTime = Date.now();
@@ -142,6 +133,6 @@ test.describe("Create Auction via Topsort SDK", () => {
     });
 
     expect(result.createAuctionResult).toEqual(mockAPIResponse);
-    expect(result.timeTaken).toBeGreaterThanOrEqual(2000);
+    expect(result.timeTaken).toBeGreaterThanOrEqual(100);
   });
 });

--- a/e2e/events.test.ts
+++ b/e2e/events.test.ts
@@ -34,10 +34,6 @@ test.describe("Report Events via Topsort SDK", () => {
         ],
       };
 
-      if (typeof window.sdk.reportEvent === "undefined") {
-        throw new Error("Global function `reportEvent` is not available.");
-      }
-
       return window.sdk.reportEvent(config, event);
     });
 
@@ -71,9 +67,6 @@ test.describe("Report Events via Topsort SDK", () => {
           },
         ],
       };
-      if (typeof window.sdk.reportEvent === "undefined") {
-        throw new Error("Global function `reportEvent` is not available.");
-      }
 
       return window.sdk.reportEvent(config, event);
     });


### PR DESCRIPTION
This PR adds an E2E test to simulate timeout being part of the config

Needs to be merged after ([#11](https://github.com/Topsort/topsort.js/pull/11))