### PR TITLE
fix: qualityScore should be optional

### DIFF
--- a/src/types/auctions.d.ts
+++ b/src/types/auctions.d.ts
@@ -19,7 +19,7 @@ interface AuctionDisjunctiveCategories {
 
 interface AuctionProduct {
   ids: string[];
-  qualityScores: number[];
+  qualityScores?: number[];
 }
 
 interface AuctionBase {


### PR DESCRIPTION
According to our API, the qualityScore is optional.