### PR TITLE
chore: improve url generation

### DIFF
--- a/src/functions/events.ts
+++ b/src/functions/events.ts
@@ -23,10 +23,10 @@ import { Config } from "../types/shared";
 async function handler(config: Config, event: TopsortEvent): Promise<EventResult> {
   let url: URL;
   try {
-    url = new URL(`${config.host || baseURL}/${apis.events}`);
+    url = new URL(apis.events, config.host || baseURL);
   } catch (error) {
     throw new AppError(400, "Invalid URL", {
-      error: `Invalid URL: ${config.host || baseURL}/${apis.events}`,
+      error: `Invalid URL: ${error}`,
     });
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "module": "ES2020",
     "target": "ES2020",
     "moduleResolution": "bundler",


### PR DESCRIPTION
`URL()` supports a second `base` argument so we don't have to construct the url ourselves.

Also, add `DOM` to lib since thats where the URL type lives.