### PR TITLE
chore: improve url generation for auctions

### DIFF
--- a/src/functions/auctions.ts
+++ b/src/functions/auctions.ts
@@ -8,10 +8,10 @@ import { Config } from "../types/shared";
 async function handler(config: Config, body: TopsortAuction): Promise<AuctionResult> {
   let url: URL;
   try {
-    url = new URL(`${config.host || baseURL}/${apis.auctions}`);
+    url = new URL(apis.auctions, config.host || baseURL);
   } catch (error) {
     throw new AppError(400, "Invalid URL", {
-      error: `Invalid URL: ${config.host || baseURL}/${apis.auctions}`,
+      error: `Invalid URL: ${error}`,
     });
   }
 


### PR DESCRIPTION
In a previous commit we improved the url generation for events but not for auctions. This PR addresses that.

Refs: https://github.com/Topsort/topsort.js/pull/39