### PR TITLE
feat: add implementation for TopsortClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ yarn add @topsort/sdk --save
 
 ### Auctions
 
-To create an auction, use the `createAuction` function. Example:
+To create an auction, first initialize Topsort Client, then use the `createAuction` function. Example:
 
 ```js
-import { TopsortAuction, createAuction } from "@topsort/sdk";
+import { TopsortClient, TopsortAuction } from "@topsort/sdk";
 
 const auctionDetails: TopsortAuction = {
   auctions: [
@@ -59,11 +59,13 @@ const config = {
   // generate your api key in the auction manager - it should look some thing like this
   // note: this is an invalid key and won't work, you need to replace it with your own
   apiKey: "TSE_4S6o1g1CB5tyRENfhDMAn6viR7A5cy3j1JAR",
-  userAgent: "Mozilla/5.0"
-  timeout: 50
+  userAgent: "Mozilla/5.0", // optional user agent to be added as part of the request
+  timeout: 50 // optional timeout signal to be added asp art of the request
 };
 
-createAuction(config, auctionDetails)
+const topsortClient = new TopsortClient(config)
+
+topsortClient.createAuction(config, auctionDetails)
   .then((result) => console.log(result))
   .catch((error) => console.error(error));
 ```
@@ -118,10 +120,10 @@ createAuction(config, auctionDetails)
 
 ### Events
 
-To report an event, use the reportEvent function. Here is an example:
+To report an event, first initialize Topsort Client, then use the `reportEvent` function. Here is an example:
 
 ```js
-import { TopsortEvent, reportEvent } from "@topsort/sdk";
+import { TopsortClient, TopsortEvent } from "@topsort/sdk";
 
 const event: TopsortEvent = {
   impressions: [
@@ -141,10 +143,12 @@ const event: TopsortEvent = {
 const config = {
   // generate your api key in the auction manager - it should look some thing like this
   apiKey: "TSE_4S6o1g1CB5tyRENfhDMAn6viR7A5cy3j1JAR",
-  userAgent?: "Mozilla/5.0" // optional user agent to be added as part of the request
+  userAgent: "Mozilla/5.0" // optional user agent to be added as part of the request
 };
 
-reportEvent(config, event)
+const topsortClient = new TopsortClient(config)
+
+topsortClient.reportEvent(config, event)
   .then((result) => console.log(result))
   .catch((error) => console.error(error));
 ```

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ yarn add @topsort/sdk --save
 
 ### Auctions
 
-To create an auction, first initialize Topsort Client, then use the `createAuction` function. Example:
+To create an auction, first initialize a Topsort Client, then call the `createAuction` function:
 
 ```js
-import { TopsortClient, TopsortAuction } from "@topsort/sdk";
+import { TopsortClient, Auction } from "@topsort/sdk";
 
-const auctionDetails: TopsortAuction = {
+const auctionDetails: Auction = {
   auctions: [
     {
       type: "listings",
@@ -60,7 +60,7 @@ const config = {
   // note: this is an invalid key and won't work, you need to replace it with your own
   apiKey: "TSE_4S6o1g1CB5tyRENfhDMAn6viR7A5cy3j1JAR",
   userAgent: "Mozilla/5.0", // optional user agent to be added as part of the request
-  timeout: 50 // optional timeout signal to be added asp art of the request
+  timeout: 50 // optional timeout for the request
 };
 
 const topsortClient = new TopsortClient(config)
@@ -120,12 +120,12 @@ topsortClient.createAuction(config, auctionDetails)
 
 ### Events
 
-To report an event, first initialize Topsort Client, then use the `reportEvent` function. Here is an example:
+To report an event, first initialize a Topsort Client, then call the `reportEvent` function:
 
 ```js
-import { TopsortClient, TopsortEvent } from "@topsort/sdk";
+import { TopsortClient, Event } from "@topsort/sdk";
 
-const event: TopsortEvent = {
+const event: Event = {
   impressions: [
     {
       resolvedBidId:

--- a/e2e/auctions.test.ts
+++ b/e2e/auctions.test.ts
@@ -19,7 +19,7 @@ test.describe("Create Auction via Topsort SDK", () => {
       ],
     };
 
-    await page.route(`${baseURL}${apis.auctions}`, async (route) => {
+    await page.route(`${baseURL}/${apis.auctions}`, async (route) => {
       await route.fulfill({ json: mockAPIResponse });
     });
 

--- a/e2e/auctions.test.ts
+++ b/e2e/auctions.test.ts
@@ -19,7 +19,7 @@ test.describe("Create Auction via Topsort SDK", () => {
       ],
     };
 
-    await page.route(`${baseURL}/${apis.auctions}`, async (route) => {
+    await page.route(`${baseURL}${apis.auctions}`, async (route) => {
       await route.fulfill({ json: mockAPIResponse });
     });
 

--- a/e2e/auctions.test.ts
+++ b/e2e/auctions.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { apis, baseURL } from "../src/constants/apis.constant";
+import { baseURL, endpoints } from "../src/constants/endpoints.constant";
 import { playwrightConstants } from "./config";
 
 test.describe("Create Auction via Topsort SDK", () => {
@@ -19,7 +19,7 @@ test.describe("Create Auction via Topsort SDK", () => {
       ],
     };
 
-    await page.route(`${baseURL}/${apis.auctions}`, async (route) => {
+    await page.route(`${baseURL}/${endpoints.auctions}`, async (route) => {
       await route.fulfill({ json: mockAPIResponse });
     });
 

--- a/e2e/events.test.ts
+++ b/e2e/events.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { apis, baseURL } from "../src/constants/apis.constant";
+import { baseURL, endpoints } from "../src/constants/endpoints.constant";
 import { playwrightConstants } from "./config";
 
 test.describe("Report Events via Topsort SDK", () => {
@@ -9,7 +9,7 @@ test.describe("Report Events via Topsort SDK", () => {
       retry: false,
     };
 
-    await page.route(`${baseURL}/${apis.events}`, async (route) => {
+    await page.route(`${baseURL}/${endpoints.events}`, async (route) => {
       await route.fulfill({ json: mockAPIResponse });
     });
 

--- a/e2e/events.test.ts
+++ b/e2e/events.test.ts
@@ -9,7 +9,7 @@ test.describe("Report Events via Topsort SDK", () => {
       retry: false,
     };
 
-    await page.route(`${baseURL}/${apis.events}`, async (route) => {
+    await page.route(`${baseURL}${apis.events}`, async (route) => {
       await route.fulfill({ json: mockAPIResponse });
     });
 

--- a/e2e/events.test.ts
+++ b/e2e/events.test.ts
@@ -9,7 +9,7 @@ test.describe("Report Events via Topsort SDK", () => {
       retry: false,
     };
 
-    await page.route(`${baseURL}${apis.events}`, async (route) => {
+    await page.route(`${baseURL}/${apis.events}`, async (route) => {
       await route.fulfill({ json: mockAPIResponse });
     });
 

--- a/e2e/public/index.html
+++ b/e2e/public/index.html
@@ -11,15 +11,15 @@
     <script>
       window.sdk = {
         createAuction: async (config, auctionDetails) => {
-          const result = await Topsort.createAuction(
-            config,
+          const topsortClient = new Topsort.TopsortClient(config)
+          const result = await topsortClient.createAuction(
             auctionDetails
           ).catch((error) => error);
           return result;
         },
         reportEvent: async (config, eventDetails) => {
-          const result = await Topsort.reportEvent(
-            config,
+          const topsortClient = new Topsort.TopsortClient(config)
+          const result = await topsortClient.reportEvent(
             eventDetails
           ).catch((error) => error);
           return result;

--- a/src/constants/apis.constant.ts
+++ b/src/constants/apis.constant.ts
@@ -1,6 +1,6 @@
 export const baseURL = "https://api.topsort.com";
 
 export const apis = {
-  auctions: "v2/auctions",
-  events: "v2/events",
+  auctions: "/v2/auctions",
+  events: "/v2/events",
 };

--- a/src/constants/apis.constant.ts
+++ b/src/constants/apis.constant.ts
@@ -1,6 +1,6 @@
 export const baseURL = "https://api.topsort.com";
 
 export const apis = {
-  auctions: "/v2/auctions",
-  events: "/v2/events",
+  auctions: "v2/auctions",
+  events: "v2/events",
 };

--- a/src/constants/endpoints.constant.ts
+++ b/src/constants/endpoints.constant.ts
@@ -1,6 +1,6 @@
 export const baseURL = "https://api.topsort.com";
 
-export const apis = {
+export const endpoints = {
   auctions: "v2/auctions",
   events: "v2/events",
 };

--- a/src/functions/auctions.ts
+++ b/src/functions/auctions.ts
@@ -4,10 +4,7 @@ import { withValidation } from "../lib/with-validation";
 import { AuctionResult, TopsortAuction } from "../types/auctions";
 import { Config } from "../types/shared";
 
-async function handler(
-  body: TopsortAuction,
-  config: Config
-): Promise<AuctionResult> {
+async function handler(body: TopsortAuction, config: Config): Promise<AuctionResult> {
   const url = `${config.host}/${apis.auctions}`;
   const result = await APIClient.post(url.toString(), body, config);
 

--- a/src/functions/auctions.ts
+++ b/src/functions/auctions.ts
@@ -8,7 +8,7 @@ async function handler(
   body: TopsortAuction,
   config: Config
 ): Promise<AuctionResult> {
-  const url = `${config.host}${apis.auctions}`;
+  const url = `${config.host}/${apis.auctions}`;
   const result = await APIClient.post(url.toString(), body, config);
 
   return result as AuctionResult;

--- a/src/functions/auctions.ts
+++ b/src/functions/auctions.ts
@@ -1,11 +1,11 @@
-import { apis } from "../constants/apis.constant";
+import { endpoints } from "../constants/endpoints.constant";
 import APIClient from "../lib/api-client";
 import { withValidation } from "../lib/with-validation";
-import { AuctionResult, TopsortAuction } from "../types/auctions";
+import { Auction, AuctionResult } from "../types/auctions";
 import { Config } from "../types/shared";
 
-async function handler(body: TopsortAuction, config: Config): Promise<AuctionResult> {
-  const url = `${config.host}/${apis.auctions}`;
+async function handler(body: Auction, config: Config): Promise<AuctionResult> {
+  const url = `${config.host}/${endpoints.auctions}`;
   const result = await APIClient.post(url.toString(), body, config);
 
   return result as AuctionResult;

--- a/src/functions/auctions.ts
+++ b/src/functions/auctions.ts
@@ -1,21 +1,16 @@
-import { apis, baseURL } from "../constants/apis.constant";
+import { apis } from "../constants/apis.constant";
 import APIClient from "../lib/api-client";
-import AppError from "../lib/app-error";
 import { withValidation } from "../lib/with-validation";
 import { AuctionResult, TopsortAuction } from "../types/auctions";
 import { Config } from "../types/shared";
 
-async function handler(config: Config, body: TopsortAuction): Promise<AuctionResult> {
-  let url: URL;
-  try {
-    url = new URL(apis.auctions, config.host || baseURL);
-  } catch (error) {
-    throw new AppError(400, "Invalid URL", {
-      error: `Invalid URL: ${error}`,
-    });
-  }
-
+async function handler(
+  body: TopsortAuction,
+  config: Config
+): Promise<AuctionResult> {
+  const url = `${config.host}${apis.auctions}`;
   const result = await APIClient.post(url.toString(), body, config);
+
   return result as AuctionResult;
 }
 

--- a/src/functions/events.ts
+++ b/src/functions/events.ts
@@ -7,7 +7,7 @@ import { Config } from "../types/shared";
 
 async function handler(event: TopsortEvent, config: Config): Promise<EventResult> {
   try {
-    const url = `${config.host}${apis.events}`;
+    const url = `${config.host}/${apis.events}`;
     await APIClient.post(url, event, config);
 
     return { ok: true, retry: false };

--- a/src/functions/events.ts
+++ b/src/functions/events.ts
@@ -1,13 +1,13 @@
-import { apis } from "../constants/apis.constant";
+import { endpoints } from "../constants/endpoints.constant";
 import APIClient from "../lib/api-client";
 import AppError from "../lib/app-error";
 import { withValidation } from "../lib/with-validation";
-import { EventResult, TopsortEvent } from "../types/events";
+import { Event, EventResult } from "../types/events";
 import { Config } from "../types/shared";
 
-async function handler(event: TopsortEvent, config: Config): Promise<EventResult> {
+async function handler(event: Event, config: Config): Promise<EventResult> {
   try {
-    const url = `${config.host}/${apis.events}`;
+    const url = `${config.host}/${endpoints.events}`;
     await APIClient.post(url, event, config);
 
     return { ok: true, retry: false };

--- a/src/functions/events.ts
+++ b/src/functions/events.ts
@@ -5,33 +5,11 @@ import { withValidation } from "../lib/with-validation";
 import { EventResult, TopsortEvent } from "../types/events";
 import { Config } from "../types/shared";
 
-/**
- * Reports an event to the Topsort API.
- *
- * @example
- * ```js
- * const config = { apiKey: "api-key" };
- * const event = { eventType: "test", eventData: {} };
- * const result = await reportEvent(config, event);
- * console.log(result); // { "ok": true }
- * ```
- *
- * @param config - The configuration object containing the API Key and optionally, the Host.
- * @param event - The event to report.
- * @returns {Promise<EventResult>} The result of the report, indicating success.
- */
-async function handler(config: Config, event: TopsortEvent): Promise<EventResult> {
-  let url: URL;
+async function handler(event: TopsortEvent, config: Config): Promise<EventResult> {
   try {
-    url = new URL(apis.events, config.host || baseURL);
-  } catch (error) {
-    throw new AppError(400, "Invalid URL", {
-      error: `Invalid URL: ${error}`,
-    });
-  }
+    const url = `${config.host}${apis.events}`;
+    await APIClient.post(url, event, config);
 
-  try {
-    await APIClient.post(url.toString(), event, config);
     return { ok: true, retry: false };
   } catch (error) {
     if (error instanceof AppError && error.retry) {

--- a/src/functions/events.ts
+++ b/src/functions/events.ts
@@ -1,4 +1,4 @@
-import { apis, baseURL } from "../constants/apis.constant";
+import { apis } from "../constants/apis.constant";
 import APIClient from "../lib/api-client";
 import AppError from "../lib/app-error";
 import { withValidation } from "../lib/with-validation";

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,2 +1,1 @@
-export * from "./auctions";
-export * from "./events";
+export { default as TopsortClient } from "./topsort-client";

--- a/src/functions/topsort-client.ts
+++ b/src/functions/topsort-client.ts
@@ -1,0 +1,42 @@
+import { baseURL } from "../constants/apis.constant";
+import AppError from "../lib/app-error";
+import {
+  AuctionResult,
+  EventResult,
+  TopsortAuction,
+  TopsortEvent,
+} from "../types";
+import { Config } from "../types/shared";
+
+import { createAuction } from "./auctions";
+import { reportEvent } from "./events";
+
+class TopsortClient {
+  private config: Config;
+
+  constructor(config: Config) {
+    this.config = config;
+    this.config.host = this.sanitizeUrl(this.config.host ?? baseURL);
+  }
+
+  private sanitizeUrl(url: string): string {
+    try {
+      const parsedUrl = new URL(url);
+      return parsedUrl.href.replace(/\/+$/, "");
+    } catch (error) {
+      throw new AppError(400, "Invalid URL", {
+        error: `Invalid URL: ${error}`,
+      });
+    }
+  }
+
+  public async reportEvent(event: TopsortEvent): Promise<EventResult> {
+    return reportEvent(event, this.config);
+  }
+
+  public async createAuction(auction: TopsortAuction): Promise<AuctionResult> {
+    return await createAuction(auction, this.config);
+  }
+}
+
+export default TopsortClient;

--- a/src/functions/topsort-client.ts
+++ b/src/functions/topsort-client.ts
@@ -16,18 +16,7 @@ class TopsortClient {
 
   constructor(config: Config) {
     this.config = config;
-    this.config.host = this.sanitizeUrl(this.config.host ?? baseURL);
-  }
-
-  private sanitizeUrl(url: string): string {
-    try {
-      const parsedUrl = new URL(url);
-      return parsedUrl.href.replace(/\/+$/, "");
-    } catch (error) {
-      throw new AppError(400, "Invalid URL", {
-        error: `Invalid URL: ${error}`,
-      });
-    }
+    this.config.host = this.config.host ?? baseURL;
   }
 
   public async reportEvent(event: TopsortEvent): Promise<EventResult> {

--- a/src/functions/topsort-client.ts
+++ b/src/functions/topsort-client.ts
@@ -1,10 +1,5 @@
 import { baseURL } from "../constants/apis.constant";
-import {
-  AuctionResult,
-  EventResult,
-  TopsortAuction,
-  TopsortEvent,
-} from "../types";
+import { AuctionResult, EventResult, TopsortAuction, TopsortEvent } from "../types";
 import { Config } from "../types/shared";
 
 import { createAuction } from "./auctions";

--- a/src/functions/topsort-client.ts
+++ b/src/functions/topsort-client.ts
@@ -1,5 +1,5 @@
-import { baseURL } from "../constants/apis.constant";
-import { AuctionResult, EventResult, TopsortAuction, TopsortEvent } from "../types";
+import { baseURL } from "../constants/endpoints.constant";
+import { Auction, AuctionResult, Event, EventResult } from "../types";
 import { Config } from "../types/shared";
 
 import { createAuction } from "./auctions";
@@ -13,11 +13,11 @@ class TopsortClient {
     this.config.host = this.config.host ?? baseURL;
   }
 
-  public async reportEvent(event: TopsortEvent): Promise<EventResult> {
+  public async reportEvent(event: Event): Promise<EventResult> {
     return reportEvent(event, this.config);
   }
 
-  public async createAuction(auction: TopsortAuction): Promise<AuctionResult> {
+  public async createAuction(auction: Auction): Promise<AuctionResult> {
     return createAuction(auction, this.config);
   }
 }

--- a/src/functions/topsort-client.ts
+++ b/src/functions/topsort-client.ts
@@ -1,11 +1,6 @@
 import { baseURL } from "../constants/apis.constant";
 import AppError from "../lib/app-error";
-import {
-  AuctionResult,
-  EventResult,
-  TopsortAuction,
-  TopsortEvent,
-} from "../types";
+import { AuctionResult, EventResult, TopsortAuction, TopsortEvent } from "../types";
 import { Config } from "../types/shared";
 
 import { createAuction } from "./auctions";
@@ -24,7 +19,7 @@ class TopsortClient {
   }
 
   public async createAuction(auction: TopsortAuction): Promise<AuctionResult> {
-    return await createAuction(auction, this.config);
+    return createAuction(auction, this.config);
   }
 }
 

--- a/src/functions/topsort-client.ts
+++ b/src/functions/topsort-client.ts
@@ -1,6 +1,10 @@
 import { baseURL } from "../constants/apis.constant";
-import AppError from "../lib/app-error";
-import { AuctionResult, EventResult, TopsortAuction, TopsortEvent } from "../types";
+import {
+  AuctionResult,
+  EventResult,
+  TopsortAuction,
+  TopsortEvent,
+} from "../types";
 import { Config } from "../types/shared";
 
 import { createAuction } from "./auctions";

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -25,7 +25,8 @@ class APIClient {
     options: RequestInit
   ): Promise<unknown> {
     try {
-      const response = await fetch(endpoint, options);
+      const sanitizedUrl = this.sanitizeUrl(endpoint);
+      const response = await fetch(sanitizedUrl, options);
       return this.handleResponse(response);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
@@ -60,6 +61,17 @@ class APIClient {
       body: JSON.stringify(body),
       signal,
     });
+  }
+
+  private sanitizeUrl(url: string): string {
+    try {
+      const parsedUrl = new URL(url);
+      return parsedUrl.href.replace(/\/+$/, "");
+    } catch (error) {
+      throw new AppError(400, "Invalid URL", {
+        error: `Invalid URL: ${error}`,
+      });
+    }
   }
 }
 

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,15 +1,8 @@
 import { version } from "../../package.json";
-import { baseURL } from "../constants/apis.constant";
 import { Config } from "../types/shared";
 import AppError from "./app-error";
 
 class APIClient {
-  private baseUrl: string;
-
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
-  }
-
   private async handleResponse(response: Response): Promise<unknown> {
     const contentType = response.headers.get("Content-Type") || "";
     let data: unknown;
@@ -27,9 +20,12 @@ class APIClient {
     return data;
   }
 
-  private async request(endpoint: string, options: RequestInit): Promise<unknown> {
+  private async request(
+    endpoint: string,
+    options: RequestInit
+  ): Promise<unknown> {
     try {
-      const response = await fetch(`${endpoint ?? this.baseUrl}`, options);
+      const response = await fetch(endpoint, options);
       return this.handleResponse(response);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
@@ -45,7 +41,11 @@ class APIClient {
     }
   }
 
-  public async post(endpoint: string, body: unknown, config: Config): Promise<unknown> {
+  public async post(
+    endpoint: string,
+    body: unknown,
+    config: Config
+  ): Promise<unknown> {
     const signal = this.setupTimeoutSignal(config);
     return this.request(endpoint, {
       method: "POST",
@@ -63,4 +63,4 @@ class APIClient {
   }
 }
 
-export default new APIClient(`${baseURL}`);
+export default new APIClient();

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -14,10 +14,7 @@ class APIClient {
     return data;
   }
 
-  private async request(
-    endpoint: string,
-    options: RequestInit
-  ): Promise<unknown> {
+  private async request(endpoint: string, options: RequestInit): Promise<unknown> {
     try {
       const sanitizedUrl = this.sanitizeUrl(endpoint);
       const response = await fetch(sanitizedUrl, options);
@@ -36,11 +33,7 @@ class APIClient {
     }
   }
 
-  public async post(
-    endpoint: string,
-    body: unknown,
-    config: Config
-  ): Promise<unknown> {
+  public async post(endpoint: string, body: unknown, config: Config): Promise<unknown> {
     const signal = this.setupTimeoutSignal(config);
     return this.request(endpoint, {
       method: "POST",

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -4,13 +4,7 @@ import AppError from "./app-error";
 
 class APIClient {
   private async handleResponse(response: Response): Promise<unknown> {
-    const contentType = response.headers.get("Content-Type") || "";
-    let data: unknown;
-    if (contentType.includes("application/json")) {
-      data = await response.json();
-    } else {
-      data = await response.text();
-    }
+    const data: unknown = await response.json();
 
     if (!response.ok) {
       const retry = response.status === 429 || response.status >= 500;

--- a/src/lib/with-validation.ts
+++ b/src/lib/with-validation.ts
@@ -2,7 +2,7 @@ import { Config } from "../types/shared";
 import { validateConfig } from "./validate-config";
 
 export function withValidation<T extends Config, U, Args extends unknown[]>(
-  fn: (...args: [...Args, T]) => Promise<U>
+  fn: (...args: [...Args, T]) => Promise<U>,
 ): (...args: [...Args, T]) => Promise<U> {
   return async (...args: [...Args, T]): Promise<U> => {
     const config = args[args.length - 1] as T;

--- a/src/lib/with-validation.ts
+++ b/src/lib/with-validation.ts
@@ -2,10 +2,12 @@ import { Config } from "../types/shared";
 import { validateConfig } from "./validate-config";
 
 export function withValidation<T extends Config, U, Args extends unknown[]>(
-  fn: (config: T, ...args: Args) => Promise<U>,
-): (config: T, ...args: Args) => Promise<U> {
-  return async (config: T, ...args: Args): Promise<U> => {
+  fn: (...args: [...Args, T]) => Promise<U>
+): (...args: [...Args, T]) => Promise<U> {
+  return async (...args: [...Args, T]): Promise<U> => {
+    const config = args[args.length - 1] as T;
     validateConfig(config);
-    return fn(config, ...args);
+
+    return fn(...args);
   };
 }

--- a/src/types/auctions.d.ts
+++ b/src/types/auctions.d.ts
@@ -41,7 +41,7 @@ interface BannerAuction extends AuctionBase {
   type: "banners";
 }
 
-export interface TopsortAuction {
+export interface Auction {
   auctions: (SponsoredListingAuction | BannerAuction)[];
 }
 

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -47,7 +47,7 @@ interface Purchase {
   opaqueUserId: string;
 }
 
-export interface TopsortEvent {
+export interface Event {
   clicks?: Click[];
   impressions?: Impression[];
   purchases?: Purchase[];

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -11,23 +11,23 @@ describe("apiClient", () => {
   it("should handle custom url with trailing slash", async () => {
     const customURL = `${baseURL}/${apis.auctions}/`;
     const config: Config = {
-        apiKey: "apiKey",
-    }
+      apiKey: "apiKey",
+    };
     returnAuctionSuccess(`${baseURL}/${apis.auctions}`);
 
     expect(APIClient.post(customURL, {} as TopsortEvent, config)).resolves.toEqual({
-        results: [
-          {
-            resultType: "listings",
-            winners: [],
-            error: false,
-          },
-          {
-            resultType: "banners",
-            winners: [],
-            error: false,
-          },
-        ],
-      });
+      results: [
+        {
+          resultType: "listings",
+          winners: [],
+          error: false,
+        },
+        {
+          resultType: "banners",
+          winners: [],
+          error: false,
+        },
+      ],
+    });
   });
 });

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it } from "bun:test";
-import { Config, TopsortEvent } from "../src";
-import { apis, baseURL } from "../src/constants/apis.constant";
+import { Config, Event } from "../src";
+import { baseURL, endpoints } from "../src/constants/endpoints.constant";
 import { mswServer, returnAuctionSuccess } from "../src/constants/handlers.constant";
 import APIClient from "../src/lib/api-client";
 
@@ -9,13 +9,13 @@ describe("apiClient", () => {
   afterEach(() => mswServer.resetHandlers());
 
   it("should handle custom url with trailing slash", async () => {
-    const customURL = `${baseURL}/${apis.auctions}/`;
+    const customURL = `${baseURL}/${endpoints.auctions}/`;
     const config: Config = {
       apiKey: "apiKey",
     };
-    returnAuctionSuccess(`${baseURL}/${apis.auctions}`);
+    returnAuctionSuccess(`${baseURL}/${endpoints.auctions}`);
 
-    expect(APIClient.post(customURL, {} as TopsortEvent, config)).resolves.toEqual({
+    expect(APIClient.post(customURL, {} as Event, config)).resolves.toEqual({
       results: [
         {
           resultType: "listings",

--- a/test/api-client.test.ts
+++ b/test/api-client.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Config, TopsortEvent } from "../src";
+import { apis, baseURL } from "../src/constants/apis.constant";
+import { mswServer, returnAuctionSuccess } from "../src/constants/handlers.constant";
+import APIClient from "../src/lib/api-client";
+
+describe("apiClient", () => {
+  beforeAll(() => mswServer.listen());
+  afterEach(() => mswServer.resetHandlers());
+
+  it("should handle custom url with trailing slash", async () => {
+    const customURL = `${baseURL}/${apis.auctions}/`;
+    const config: Config = {
+        apiKey: "apiKey",
+    }
+    returnAuctionSuccess(`${baseURL}/${apis.auctions}`);
+
+    expect(APIClient.post(customURL, {} as TopsortEvent, config)).resolves.toEqual({
+        results: [
+          {
+            resultType: "listings",
+            winners: [],
+            error: false,
+          },
+          {
+            resultType: "banners",
+            winners: [],
+            error: false,
+          },
+        ],
+      });
+  });
+});

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { TopsortClient } from "../src";
-import { apis, baseURL } from "../src/constants/apis.constant";
+import { baseURL, endpoints } from "../src/constants/endpoints.constant";
 import {
   mswServer,
   returnAuctionSuccess,
@@ -8,7 +8,7 @@ import {
   returnStatus,
 } from "../src/constants/handlers.constant";
 import AppError from "../src/lib/app-error";
-import { TopsortAuction } from "../src/types/auctions";
+import { Auction } from "../src/types/auctions";
 
 describe("createAuction", () => {
   let topsortClient: TopsortClient;
@@ -19,8 +19,8 @@ describe("createAuction", () => {
   });
 
   it("should handle authentication error", async () => {
-    returnStatus(401, `${baseURL}/${apis.auctions}`);
-    expect(topsortClient.createAuction({} as TopsortAuction)).rejects.toEqual({
+    returnStatus(401, `${baseURL}/${endpoints.auctions}`);
+    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -29,8 +29,8 @@ describe("createAuction", () => {
   });
 
   it("should handle retryable error", async () => {
-    returnStatus(429, `${baseURL}/${apis.auctions}`);
-    expect(topsortClient.createAuction({} as TopsortAuction)).rejects.toEqual({
+    returnStatus(429, `${baseURL}/${endpoints.auctions}`);
+    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 429,
       retry: true,
       statusText: "Too Many Requests",
@@ -39,8 +39,8 @@ describe("createAuction", () => {
   });
 
   it("should handle server error", async () => {
-    returnStatus(500, `${baseURL}/${apis.auctions}`);
-    expect(topsortClient.createAuction({} as TopsortAuction)).rejects.toEqual({
+    returnStatus(500, `${baseURL}/${endpoints.auctions}`);
+    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 500,
       retry: true,
       statusText: "Internal Server Error",
@@ -49,13 +49,13 @@ describe("createAuction", () => {
   });
 
   it("should handle custom url", async () => {
-    returnAuctionSuccess(`https://demo.api.topsort.com/${apis.auctions}`);
+    returnAuctionSuccess(`https://demo.api.topsort.com/${endpoints.auctions}`);
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
       host: "https://demo.api.topsort.com",
     });
 
-    expect(topsortClient.createAuction({} as TopsortAuction)).resolves.toEqual({
+    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",
@@ -72,25 +72,25 @@ describe("createAuction", () => {
   });
 
   it("should handle fetch error", async () => {
-    returnError(`${baseURL}/${apis.auctions}`);
-    expect(async () => topsortClient.createAuction({} as TopsortAuction)).toThrow(AppError);
+    returnError(`${baseURL}/${endpoints.auctions}`);
+    expect(async () => topsortClient.createAuction({} as Auction)).toThrow(AppError);
   });
 
   it("should handle invalid URL error", async () => {
     const invalidHost = "invalid-url";
     topsortClient = new TopsortClient({ apiKey: "apiKey", host: invalidHost });
-    expect(async () => topsortClient.createAuction({} as TopsortAuction)).toThrow(AppError);
+    expect(async () => topsortClient.createAuction({} as Auction)).toThrow(AppError);
   });
 
   it("should handle success auction with timeout", async () => {
-    returnAuctionSuccess(`${baseURL}/${apis.auctions}`);
+    returnAuctionSuccess(`${baseURL}/${endpoints.auctions}`);
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
       host: baseURL,
       timeout: 50,
     });
 
-    expect(topsortClient.createAuction({} as TopsortAuction)).resolves.toEqual({
+    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -36,7 +36,7 @@ describe("createAuction", () => {
   });
 
   it("should handle retryable error", async () => {
-    returnStatus(429, `${baseURL}${apis.auctions}`);
+    returnStatus(429, `${baseURL}/${apis.auctions}`);
     expect(topsortClient.createAuction({} as TopsortAuction)).rejects.toEqual({
       status: 429,
       retry: true,
@@ -46,7 +46,7 @@ describe("createAuction", () => {
   });
 
   it("should handle server error", async () => {
-    returnStatus(500, `${baseURL}${apis.auctions}`);
+    returnStatus(500, `${baseURL}/${apis.auctions}`);
     expect(topsortClient.createAuction({} as TopsortAuction)).rejects.toEqual({
       status: 500,
       retry: true,
@@ -56,7 +56,7 @@ describe("createAuction", () => {
   });
 
   it("should handle custom url", async () => {
-    returnAuctionSuccess(`https://demo.api.topsort.com${apis.auctions}`);
+    returnAuctionSuccess(`https://demo.api.topsort.com/${apis.auctions}`);
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
       host: "https://demo.api.topsort.com",
@@ -79,7 +79,7 @@ describe("createAuction", () => {
   });
 
   it("should handle fetch error", async () => {
-    returnError(`${baseURL}${apis.auctions}`);
+    returnError(`${baseURL}/${apis.auctions}`);
     expect(async () =>
       topsortClient.createAuction({} as TopsortAuction)
     ).toThrow(AppError);
@@ -91,5 +91,29 @@ describe("createAuction", () => {
     expect(async () =>
       topsortClient.createAuction({} as TopsortAuction)
     ).toThrow(AppError);
+  });
+
+  it("should handle success auction with timeout", async () => {
+    returnAuctionSuccess(`${baseURL}/${apis.auctions}`);
+    topsortClient = new TopsortClient({
+      apiKey: "apiKey",
+      host: baseURL,
+      timeout: 50
+    });
+
+    expect(topsortClient.createAuction({} as TopsortAuction)).resolves.toEqual({
+      results: [
+        {
+          resultType: "listings",
+          winners: [],
+          error: false,
+        },
+        {
+          resultType: "banners",
+          winners: [],
+          error: false,
+        },
+      ],
+    });
   });
 });

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -26,7 +26,7 @@ describe("createAuction", () => {
   });
 
   it("should handle authentication error", async () => {
-    returnStatus(401, `${baseURL}${apis.auctions}`);
+    returnStatus(401, `${baseURL}/${apis.auctions}`);
     expect(topsortClient.createAuction({} as TopsortAuction)).rejects.toEqual({
       status: 401,
       retry: false,

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -1,11 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  beforeAll,
-  describe,
-  expect,
-  it,
-} from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { TopsortClient } from "../src";
 import { apis, baseURL } from "../src/constants/apis.constant";
 import {
@@ -80,17 +73,13 @@ describe("createAuction", () => {
 
   it("should handle fetch error", async () => {
     returnError(`${baseURL}/${apis.auctions}`);
-    expect(async () =>
-      topsortClient.createAuction({} as TopsortAuction)
-    ).toThrow(AppError);
+    expect(async () => topsortClient.createAuction({} as TopsortAuction)).toThrow(AppError);
   });
 
   it("should handle invalid URL error", async () => {
     const invalidHost = "invalid-url";
     topsortClient = new TopsortClient({ apiKey: "apiKey", host: invalidHost });
-    expect(async () =>
-      topsortClient.createAuction({} as TopsortAuction)
-    ).toThrow(AppError);
+    expect(async () => topsortClient.createAuction({} as TopsortAuction)).toThrow(AppError);
   });
 
   it("should handle success auction with timeout", async () => {
@@ -98,7 +87,7 @@ describe("createAuction", () => {
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
       host: baseURL,
-      timeout: 50
+      timeout: 50,
     });
 
     expect(topsortClient.createAuction({} as TopsortAuction)).resolves.toEqual({

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -24,7 +24,7 @@ describe("reportEvent", () => {
   });
 
   it("should handle authentication error", async () => {
-    returnStatus(401, `${baseURL}${apis.events}`);
+    returnStatus(401, `${baseURL}/${apis.events}`);
     expect(topsortClient.reportEvent({} as TopsortEvent)).rejects.toEqual({
       status: 401,
       retry: false,
@@ -34,7 +34,7 @@ describe("reportEvent", () => {
   });
 
   it("should handle retryable error", async () => {
-    returnStatus(429, `${baseURL}${apis.events}`);
+    returnStatus(429, `${baseURL}/${apis.events}`);
     expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
       ok: false,
       retry: true,
@@ -42,7 +42,7 @@ describe("reportEvent", () => {
   });
 
   it("should handle server error", async () => {
-    returnStatus(500, `${baseURL}${apis.events}`);
+    returnStatus(500, `${baseURL}/${apis.events}`);
     expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
       ok: false,
       retry: true,
@@ -50,7 +50,7 @@ describe("reportEvent", () => {
   });
 
   it("should handle custom url", async () => {
-    returnStatus(200, `https://demo.api.topsort.com${apis.events}`);
+    returnStatus(200, `https://demo.api.topsort.com/${apis.events}`);
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
       host: "https://demo.api.topsort.com/",
@@ -62,7 +62,7 @@ describe("reportEvent", () => {
   });
 
   it("should handle fetch error", async () => {
-    returnError(`${baseURL}${apis.events}`);
+    returnError(`${baseURL}/${apis.events}`);
     expect(
       async () => await topsortClient.reportEvent({} as TopsortEvent)
     ).toThrow(AppError);

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -50,11 +50,12 @@ describe("reportEvent", () => {
   });
 
   it("should handle custom url", async () => {
-    returnStatus(200, `https://demo.api.topsort.com/${apis.events}`);
+    returnStatus(204, `https://demo.api.topsort.com/${apis.events}`);
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
-      host: "https://demo.api.topsort.com/",
+      host: "https://demo.api.topsort.com",
     });
+
     expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
       ok: true,
       retry: false,

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { TopsortClient, TopsortEvent } from "../src";
-import { apis, baseURL } from "../src/constants/apis.constant";
+import { Event, TopsortClient } from "../src";
+import { baseURL, endpoints } from "../src/constants/endpoints.constant";
 import { mswServer, returnError, returnStatus } from "../src/constants/handlers.constant";
 import AppError from "../src/lib/app-error";
 
@@ -13,8 +13,8 @@ describe("reportEvent", () => {
   });
 
   it("should handle authentication error", async () => {
-    returnStatus(401, `${baseURL}/${apis.events}`);
-    expect(topsortClient.reportEvent({} as TopsortEvent)).rejects.toEqual({
+    returnStatus(401, `${baseURL}/${endpoints.events}`);
+    expect(topsortClient.reportEvent({} as Event)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -23,42 +23,42 @@ describe("reportEvent", () => {
   });
 
   it("should handle retryable error", async () => {
-    returnStatus(429, `${baseURL}/${apis.events}`);
-    expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
+    returnStatus(429, `${baseURL}/${endpoints.events}`);
+    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: false,
       retry: true,
     });
   });
 
   it("should handle server error", async () => {
-    returnStatus(500, `${baseURL}/${apis.events}`);
-    expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
+    returnStatus(500, `${baseURL}/${endpoints.events}`);
+    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: false,
       retry: true,
     });
   });
 
   it("should handle custom url", async () => {
-    returnStatus(204, `https://demo.api.topsort.com/${apis.events}`);
+    returnStatus(204, `https://demo.api.topsort.com/${endpoints.events}`);
     topsortClient = new TopsortClient({
       apiKey: "apiKey",
       host: "https://demo.api.topsort.com",
     });
 
-    expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
+    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: true,
       retry: false,
     });
   });
 
   it("should handle fetch error", async () => {
-    returnError(`${baseURL}/${apis.events}`);
-    expect(async () => await topsortClient.reportEvent({} as TopsortEvent)).toThrow(AppError);
+    returnError(`${baseURL}/${endpoints.events}`);
+    expect(async () => await topsortClient.reportEvent({} as Event)).toThrow(AppError);
   });
 
   it("should handle invalid URL error", async () => {
     const invalidHost = "invalid-url";
     topsortClient = new TopsortClient({ apiKey: "apiKey", host: invalidHost });
-    expect(async () => topsortClient.reportEvent({} as TopsortEvent)).toThrow(AppError);
+    expect(async () => topsortClient.reportEvent({} as Event)).toThrow(AppError);
   });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,18 +1,7 @@
-import {
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { TopsortClient, TopsortEvent } from "../src";
 import { apis, baseURL } from "../src/constants/apis.constant";
-import {
-  mswServer,
-  returnError,
-  returnStatus,
-} from "../src/constants/handlers.constant";
+import { mswServer, returnError, returnStatus } from "../src/constants/handlers.constant";
 import AppError from "../src/lib/app-error";
 
 describe("reportEvent", () => {
@@ -64,16 +53,12 @@ describe("reportEvent", () => {
 
   it("should handle fetch error", async () => {
     returnError(`${baseURL}/${apis.events}`);
-    expect(
-      async () => await topsortClient.reportEvent({} as TopsortEvent)
-    ).toThrow(AppError);
+    expect(async () => await topsortClient.reportEvent({} as TopsortEvent)).toThrow(AppError);
   });
 
   it("should handle invalid URL error", async () => {
     const invalidHost = "invalid-url";
     topsortClient = new TopsortClient({ apiKey: "apiKey", host: invalidHost });
-    expect(async () => topsortClient.reportEvent({} as TopsortEvent)).toThrow(
-      AppError
-    );
+    expect(async () => topsortClient.reportEvent({} as TopsortEvent)).toThrow(AppError);
   });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,16 +1,31 @@
-import { afterEach, beforeAll, describe, expect, it } from "bun:test";
-import { TopsortEvent, reportEvent } from "../src";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import { TopsortClient, TopsortEvent } from "../src";
 import { apis, baseURL } from "../src/constants/apis.constant";
-import { mswServer, returnError, returnStatus } from "../src/constants/handlers.constant";
+import {
+  mswServer,
+  returnError,
+  returnStatus,
+} from "../src/constants/handlers.constant";
 import AppError from "../src/lib/app-error";
 
 describe("reportEvent", () => {
+  let topsortClient: TopsortClient;
   beforeAll(() => mswServer.listen());
   afterEach(() => mswServer.resetHandlers());
+  beforeEach(() => {
+    topsortClient = new TopsortClient({ apiKey: "apiKey" });
+  });
 
   it("should handle authentication error", async () => {
-    returnStatus(401, `${baseURL}/${apis.events}`);
-    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).rejects.toEqual({
+    returnStatus(401, `${baseURL}${apis.events}`);
+    expect(topsortClient.reportEvent({} as TopsortEvent)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -19,57 +34,45 @@ describe("reportEvent", () => {
   });
 
   it("should handle retryable error", async () => {
-    returnStatus(429, `${baseURL}/${apis.events}`);
-    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).resolves.toEqual({
+    returnStatus(429, `${baseURL}${apis.events}`);
+    expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
       ok: false,
       retry: true,
     });
   });
 
   it("should handle server error", async () => {
-    returnStatus(500, `${baseURL}/${apis.events}`);
-    expect(reportEvent({ apiKey: "apiKey" }, {} as TopsortEvent)).resolves.toEqual({
+    returnStatus(500, `${baseURL}${apis.events}`);
+    expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
       ok: false,
       retry: true,
     });
   });
 
   it("should handle custom url", async () => {
-    returnStatus(200, `https://demo.api.topsort.com/${apis.events}`);
-    expect(
-      reportEvent(
-        {
-          apiKey: "apiKey",
-          host: "https://demo.api.topsort.com",
-        },
-        {} as TopsortEvent,
-      ),
-    ).resolves.toEqual({ ok: true, retry: false });
+    returnStatus(200, `https://demo.api.topsort.com${apis.events}`);
+    topsortClient = new TopsortClient({
+      apiKey: "apiKey",
+      host: "https://demo.api.topsort.com/",
+    });
+    expect(topsortClient.reportEvent({} as TopsortEvent)).resolves.toEqual({
+      ok: true,
+      retry: false,
+    });
   });
 
   it("should handle fetch error", async () => {
-    returnError(`${baseURL}/${apis.events}`);
+    returnError(`${baseURL}${apis.events}`);
     expect(
-      async () =>
-        await reportEvent(
-          {
-            apiKey: "apiKey",
-          },
-          {} as TopsortEvent,
-        ),
+      async () => await topsortClient.reportEvent({} as TopsortEvent)
     ).toThrow(AppError);
   });
 
   it("should handle invalid URL error", async () => {
     const invalidHost = "invalid-url";
-    expect(async () =>
-      reportEvent(
-        {
-          apiKey: "apiKey",
-          host: invalidHost,
-        },
-        {} as TopsortEvent,
-      ),
-    ).toThrow(AppError);
+    topsortClient = new TopsortClient({ apiKey: "apiKey", host: invalidHost });
+    expect(async () => topsortClient.reportEvent({} as TopsortEvent)).toThrow(
+      AppError
+    );
   });
 });


### PR DESCRIPTION
This PR implements the TopsortClient as part of the configuration initialization.
It also includes an endpoint sanitizer to prevent trailing slashes from passing through.

Closes: https://topsort.atlassian.net/browse/API-1147