### PR TITLE
chore: @topsort/sdk 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,84 @@ We follow the format used by [Open Telemetry](https://github.com/open-telemetry/
 
 - Add implementation for TopsortClient ([#43](https://github.com/Topsort/topsort.js/pull/43))
 
-As part of new implementation, now a client is initialized receiving a config as `const topsortClient = new TopsortClient(config)`
-And all the functions will be found within the client, as `topsortClient.createAuction(auction)` or `topsortClient.reportEvent(event)`
+As part of the new implementation, a Topsort Client that embeds all functions is now initialized by receiving a config. Additionally, some type names have been renamed:
+- _TopsortAuction_ > **Auction**
+- _TopsortEvents_ > **Event**
+
+Migration steps:
+
+#### Auctions - Before
+```js
+import { TopsortAuction, Config, reportAuction } from "@topsort/sdk";
+
+const auction: TopsortAuction = {
+    //...
+};
+
+const config: Config = {
+  apiKey: "API_KEY",
+};
+
+createAuction(config, auction)
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
+```
+
+#### Auctions - After
+```js
+import { Auction, Config, TopsortClient } from "@topsort/sdk";
+
+const auction: Auction = {
+    //...
+};
+
+const config: Config = {
+  apiKey: "API_KEY",
+};
+
+const topsortClient = new TopsortClient(config);
+
+topsortClient.createAuction(auction)
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
+```
+
+
+#### Events - Before
+```js
+import { TopsortEvent, Config, reportEvent } from "@topsort/sdk";
+
+const event: TopsortEvent = {
+    //...
+};
+
+const config: Config = {
+  apiKey: "API_KEY",
+};
+
+reportEvent(config, event)
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
+```
+
+#### Events - After
+```js
+import { Event, Config, TopsortClient } from "@topsort/sdk";
+
+const event: Event = {
+    //...
+};
+
+const config: Config = {
+  apiKey: "API_KEY",
+};
+
+const topsortClient = new TopsortClient(config);
+
+topsortClient.reportEvent(event)
+  .then((result) => console.log(result))
+  .catch((error) => console.error(error));
+```
 
 - Fix CI/CD for release process ([#38](https://github.com/Topsort/topsort.js/pull/38))
 - Convert some parameters to optional ([#36](https://github.com/Topsort/topsort.js/pull/36))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 We follow the format used by [Open Telemetry](https://github.com/open-telemetry/opentelemetry-python/blob/main/CHANGELOG.md).
 
+## Version 0.3.0 (2024-08-13)
+
+- Add implementation for TopsortClient ([#43](https://github.com/Topsort/topsort.js/pull/43))
+
+As part of new implementation, now a client is initialized receiving a config as `const topsortClient = new TopsortClient(config)`
+And all the functions will be found within the client, as `topsortClient.createAuction(auction)` or `topsortClient.reportEvent(event)`
+
+- Fix CI/CD for release process ([#38](https://github.com/Topsort/topsort.js/pull/38))
+- Convert some parameters to optional ([#36](https://github.com/Topsort/topsort.js/pull/36))
+
 ## Version 0.2.1 (2024-08-05)
 
 - Add support for Typescript with lower versions ([#37](https://github.com/Topsort/topsort.js/pull/37))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ We follow the format used by [Open Telemetry](https://github.com/open-telemetry/
 
 ## Version 0.3.0 (2024-08-13)
 
-- Add implementation for TopsortClient ([#43](https://github.com/Topsort/topsort.js/pull/43))
+- Introduce a new way to initialize a client ([#43](https://github.com/Topsort/topsort.js/pull/43))
 
 As part of the new implementation, a Topsort Client that embeds all functions is now initialized by receiving a config. Additionally, some type names have been renamed:
 - _TopsortAuction_ > **Auction**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ We follow the format used by [Open Telemetry](https://github.com/open-telemetry/
 
 - Introduce a new way to initialize a client ([#43](https://github.com/Topsort/topsort.js/pull/43))
 
-As part of the new implementation, a Topsort Client that embeds all functions is now initialized by receiving a config. Additionally, some type names have been renamed:
+As part of the new implementation, a Topsort Client that embeds all functions is now initialized by receiving a config. Also, some types have been simplified:
 - _TopsortAuction_ > **Auction**
 - _TopsortEvents_ > **Event**
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const config = {
 
 const topsortClient = new TopsortClient(config)
 
-topsortClient.createAuction(config, auctionDetails)
+topsortClient.createAuction(auctionDetails)
   .then((result) => console.log(result))
   .catch((error) => console.error(error));
 ```
@@ -148,7 +148,7 @@ const config = {
 
 const topsortClient = new TopsortClient(config)
 
-topsortClient.reportEvent(config, event)
+topsortClient.reportEvent(event)
   .then((result) => console.log(result))
   .catch((error) => console.error(error));
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@topsort/sdk",
   "version": "0.3.0",
-  "description": "",
+  "description": "The official Topsort SDK for TypeScript and JavaScript",
   "packageManager": "bun@1.1.20",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topsort/sdk",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "",
   "packageManager": "bun@1.1.20",
   "main": "dist/index.js",


### PR DESCRIPTION
This PR adds the changelog for 0.3.0 and bumps the SDK version