### PR TITLE
fix: add permission bits to publish job

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -8,6 +8,9 @@ jobs:
   npm-publish:
     name: Publish to NPM
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
An attempt to make the publish job work successfully.

Refs: https://github.com/Topsort/topsort.js/actions/runs/10375017729/job/28723765594#step:8:36