### PR TITLE
chore: adds repository, bugs and keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "module": "dist/index.mjs",
   "author": "Márcio Barbosa <marcio@topsort.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Topsort/topsort.js"
+  },
+  "bugs": {
+    "url": "https://github.com/Topsort/topsort.js/issues"
+  },
   "exports": {
     ".": {
       "import": {
@@ -46,5 +53,11 @@
     "msw": "2.3.5",
     "tsup": "8.2.4",
     "typescript": "5.5.4"
-  }
+  },
+  "keywords": [
+    "topsort",
+    "sdk",
+    "javascript",
+    "typescript"
+  ]
 }


### PR DESCRIPTION
This PR adds `repository`, `bugs` and `keywords` objects as part of package.json

- `repository` - The URL to the repository
- `bugs` - The URL for users to report issues with the SDK
- `keywords` - To help discoverability on NPM