### PR TITLE
feat: simplify tsup copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "bun -b tsup",
     "test:e2e": "bun run build && playwright test",
     "format": "biome check",
     "format:fix": "biome check --write",
@@ -54,10 +54,5 @@
     "tsup": "8.2.4",
     "typescript": "5.5.4"
   },
-  "keywords": [
-    "topsort",
-    "sdk",
-    "javascript",
-    "typescript"
-  ]
+  "keywords": ["topsort", "sdk", "javascript", "typescript"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,14 +1,14 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["cjs", "esm", "iife"],
-  dts: true,
   clean: true,
-  minify: true,
+  dts: true,
+  entry: ["src/index.ts"],
   esbuildOptions(options) {
-    options.keepNames = true;
     options.globalName = "Topsort";
+    options.keepNames = true;
   },
-  onSuccess: "cp -r ./e2e/public/* dist",
+  format: ["cjs", "esm", "iife"],
+  minify: true,
+  publicDir: "e2e/public",
 });


### PR DESCRIPTION
Avoid using a shell and use the built-in `publicDir` instead.