### PR TITLE
chore(deps): pin msw 2.4.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.lockb binary diff=lockb

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,10 @@
     {
       "matchPackagePatterns": ["bun"],
       "rangeStrategy": "in-range-only"
+    },
+    {
+      "matchPackageNames": ["msw"],
+      "allowedVersions": "<=2.4.3"
     }
   ],
   "regexManagers": [

--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "**/*.ts"
+      - "./bun.lockb" # dependencies have changed
   push:
     branches:
       - main

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@topsort/sdk",
   "version": "0.3.1",
   "description": "The official Topsort SDK for TypeScript and JavaScript",
-  "packageManager": "bun@1.1.20",
+  "packageManager": "bun@1.1.28",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "author": "Márcio Barbosa <marcio@topsort.com>",


### PR DESCRIPTION
This "fixes" a bug where the test suite fails when using bun:

```javascript
# Unhandled error between tests
-------------------------------
1 | (function (entry, fetcher)
    ^
SyntaxError: Export named 'HTTPParser' not found in module 'http'.
-------------------------------
```

Also, mark `*.lockb` as binary to avoid line-by-line diffing. You can get a pretty output by adding this to your local git config:
```shell
git config --global diff.lockb.textconv bun
git config --global diff.lockb.binary true
```