### PR TITLE
feat: run e2e tests in PRs

### DIFF
--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -37,4 +37,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
 
+      - name: Install Playwright Browsers
+        run: bunx playwright install --with-deps
+
       - run: bun test:e2e


### PR DESCRIPTION
This was missing and apparently failed while publishing `0.3.3`.