### PR TITLE
feat: pass `fetchOptions` to fetch client

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,14 @@ topsortClient.createAuction(auctionDetails)
 - `apiKey`: Your Topsort API Key
 - `userAgent`: Optional user agent to be added as part of the request. Example: `Mozilla/5.0`
 - `timeout`: Optional timeout in milliseconds. Default is 30 seconds. If timeout is reached, the call will be rejected with an [AbortError](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#aborterror).
-- `keepalive`: Optional boolean to enable keepalive for requests. Defaults to `true`. When enabled, requests will continue even if the page is being unloaded, which is useful for analytics and event tracking.
+- `fetchOptions`: Optional fetch options to pass to the fetch call. Defaults to `{ keepalive: true }`.
 
 `auctionDetails`: An object containing the details of the auction to be created, please refer to [Topsort's Auction API doc](https://docs.topsort.com/reference/createauctions) for body specification.
+
+##### Overriding fetch options
+
+By default, we pass `{ keepalive: true }` to fetch while making requests to our APIs. If you want to pass other options
+or disable fetch due to the browser/engine version required, you can do so by overriding the `fetchOptions` object.
 
 #### Sample response
 
@@ -167,7 +172,7 @@ topsortClient.reportEvent(event)
 - `apiKey`: Your Topsort API Key
 - `userAgent`: Optional user agent to be added as part of the request. Example: `Mozilla/5.0`
 - `timeout`: Optional timeout in milliseconds. Default is 30 seconds. If timeout is reached, the call will be rejected with an [AbortError](https://developer.mozilla.org/en-US/docs/Web/API/DOMException#aborterror).
-- `keepalive`: Optional boolean to enable keepalive for requests. Defaults to `true`. When enabled, requests will continue even if the page is being unloaded, which is useful for analytics and event tracking.
+- `fetchOptions`: Optional fetch options to pass to the fetch call. Defaults to `{ keepalive: true }`. When keepalive is enabled, requests will continue even if the page is being unloaded, which is useful for analytics and event tracking.
 
 `event`: An object containing the details of the event to be reported, please refer to [Topsort's Event API doc](https://docs.topsort.com/reference/reportevents) for body specification.
 

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -39,6 +39,7 @@ class APIClient {
 
   public async post(endpoint: string, body: unknown, config: Config): Promise<unknown> {
     const signal = this.setupTimeoutSignal(config);
+    const fetchOptions = config.fetchOptions ?? { keepalive: true };
     return this.request(endpoint, {
       method: "POST",
       headers: {
@@ -51,7 +52,7 @@ class APIClient {
       },
       body: JSON.stringify(body),
       signal,
-      keepalive: config.keepalive ?? true,
+      ...fetchOptions,
     });
   }
 

--- a/src/types/shared.d.ts
+++ b/src/types/shared.d.ts
@@ -6,6 +6,6 @@ export interface Config {
   /// An optional timeout for requests in milliseconds.
   timeout?: number;
   userAgent?: string;
-  /// Whether to use keepalive for requests. Defaults to true.
-  keepalive?: boolean;
+  /// Optional fetch options to pass to the fetch call. Defaults to { keepalive: true }.
+  fetchOptions?: RequestInit;
 }

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -105,4 +105,28 @@ describe("createAuction", () => {
       ],
     });
   });
+
+  it("should handle custom fetchOptions", async () => {
+    returnAuctionSuccess(`${baseURL}/${endpoints.auctions}`);
+    topsortClient = new TopsortClient({
+      apiKey: "apiKey",
+      host: baseURL,
+      fetchOptions: { keepalive: false, cache: "no-cache" },
+    });
+
+    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+      results: [
+        {
+          resultType: "listings",
+          winners: [],
+          error: false,
+        },
+        {
+          resultType: "banners",
+          winners: [],
+          error: false,
+        },
+      ],
+    });
+  });
 });

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -61,4 +61,18 @@ describe("reportEvent", () => {
     topsortClient = new TopsortClient({ apiKey: "apiKey", host: invalidHost });
     expect(async () => topsortClient.reportEvent({} as Event)).toThrow(AppError);
   });
+
+  it("should handle custom fetchOptions", async () => {
+    returnStatus(204, `${baseURL}/${endpoints.events}`);
+    topsortClient = new TopsortClient({
+      apiKey: "apiKey",
+      host: baseURL,
+      fetchOptions: { keepalive: false, cache: "no-cache" },
+    });
+
+    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+      ok: true,
+      retry: false,
+    });
+  });
 });


### PR DESCRIPTION
This PR replaces the previous keepalive behavior with a way to override all options passed to `fetch()`. The benefit here is that additional headers that a user might require are available.

Since we didn't post a release on npm, we will not treat this as an ABI breaking version.