### PR TITLE
fix: install browsers in npm publish job

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run tests
         run: bun test
 
+      - name: Install Playwright Browsers
+        run: bunx playwright install --with-deps
+
       - name: Run e2e tests
         run: bun test:e2e
         


### PR DESCRIPTION
This accidentally got removed during the 0.3.5 release cycle.