### PR TITLE
fix: don't invoke direct dependencies in the publish action

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Install Playwright Browsers
         run: bunx playwright install --with-deps
 
+        # The `test:e2e` command invokes `bun build` but we keep it here in case it changes
+      - name: Run e2e tests
+        run: bun run build
+
       - name: Run e2e tests
         run: bun test:e2e
-        
-      - name: Build artifacts
-        run: node_modules/.bin/tsup
 
       - name: Publish to npm
         id: publish


### PR DESCRIPTION
Since we now use `bunup`, `tsup` will fail. We instead call the package command even though `test:e2e` already does it for us to avoid similar issues in the future.