### PR TITLE
fix(ci): update lockfile glob and bump actionlint to v1.7.11

### DIFF
--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     paths:
       - "**/*.ts"
-      - "./bun.lockb" # dependencies have changed
+      - "bun.lock" # dependencies have changed
   push:
     branches:
       - main

--- a/.github/workflows/validate-actions.yml
+++ b/.github/workflows/validate-actions.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Install Actionlint
         env:
-          version: "1.7.10"
+          version: "1.7.11"
         run: curl -Ls "https://github.com/rhysd/actionlint/releases/download/v${{ env.version }}/actionlint_${{ env.version }}_linux_amd64.tar.gz" | sudo tar -x -z -C /usr/local/bin actionlint
 
       - name: Run Actionlint


### PR DESCRIPTION
## Summary
- Fix `test-bun.yml` path filter: `"./bun.lockb"` → `"bun.lock"` (removes invalid `./` prefix rejected by actionlint v1.7.11, and corrects the filename to match the actual lockfile)
- Bump actionlint from v1.7.10 to v1.7.11 in `validate-actions.yml`

Closes #219

## Test plan
- [ ] `validate-actions` CI job passes (actionlint v1.7.11 no longer rejects the glob)
- [ ] `test-bun` workflow still triggers correctly on lockfile changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)