### PR TITLE
feat: add opaqueUserId and page fields to auction requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ const auctionDetails: Auction = {
       slots: 3,
       category: { id: "cat123" },
       geoTargeting: { location: "US" },
+      opaqueUserId: "71303ce0-de89-496d-8270-6434589615e8",
+      page: { pageId: "category-cat123", type: "category", value: "cat123" },
     },
     {
       type: "banners",
@@ -59,6 +61,8 @@ const auctionDetails: Auction = {
       slotId: "slot123",
       category: { ids: ["cat1", "cat2"] },
       geoTargeting: { location: "UK" },
+      opaqueUserId: "71303ce0-de89-496d-8270-6434589615e8",
+      page: { pageId: "/cart", type: "cart", value: ["p_1", "p_2"] },
     },
   ],
 };

--- a/src/types/auctions.d.ts
+++ b/src/types/auctions.d.ts
@@ -1,3 +1,4 @@
+import type { Page } from "./events";
 import type { DeviceType } from "./shared";
 
 /**
@@ -151,6 +152,28 @@ interface AuctionBase {
    * @required
    */
   type: AuctionType;
+
+  /**
+   * Anonymized unique identifier that maps to the original user ID without revealing the original value.
+   * Allows Topsort to correlate user activity between auctions and user interactions, independent of the
+   * user's logged-in status. For apps or sites where users might interact while logged out, we recommend
+   * generating a random identifier (UUIDv7) on the first load, storing it on local storage (cookie, local
+   * storage, etc), and letting it live for at least a year. Otherwise, if your users are always logged in
+   * for interactions, you may use a hash of your customer ID. Correct purchase attribution requires
+   * long-lived opaque user IDs consistent between auction and event requests.
+   * @type {string}
+   * @optional
+   * @example "71303ce0-de89-496d-8270-6434589615e8"
+   */
+  opaqueUserId?: string;
+
+  /**
+   * Information about the page where the auction occurs.
+   * Use StandardPage for single-value pages or CartPage for cart pages with multiple product IDs.
+   * @type {Page}
+   * @optional
+   */
+  page?: Page;
 }
 
 /**

--- a/test/auctions.test.ts
+++ b/test/auctions.test.ts
@@ -129,4 +129,41 @@ describe("createAuction", () => {
       ],
     });
   });
+
+  it("should accept opaqueUserId and page on auction requests", async () => {
+    returnAuctionSuccess(`${baseURL}/${endpoints.auctions}`);
+    const auction: Auction = {
+      auctions: [
+        {
+          type: "listings",
+          slots: 2,
+          products: { ids: ["p_1", "p_2"] },
+          opaqueUserId: "71303ce0-de89-496d-8270-6434589615e8",
+          page: { pageId: "/search", type: "search", value: "vanilla yogurt" },
+        },
+        {
+          type: "banners",
+          slots: 1,
+          slotId: "categories-ribbon-banner",
+          opaqueUserId: "71303ce0-de89-496d-8270-6434589615e8",
+          page: { pageId: "/cart", type: "cart", value: ["p_1", "p_2"] },
+        },
+      ],
+    };
+
+    expect(topsortClient.createAuction(auction)).resolves.toEqual({
+      results: [
+        {
+          resultType: "listings",
+          winners: [],
+          error: false,
+        },
+        {
+          resultType: "banners",
+          winners: [],
+          error: false,
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds optional `opaqueUserId` to `AuctionBase` (applies to both sponsored listings and banner auctions), matching the field documented in [create-auctions](https://docs.topsort.com/en/api-reference/auctions/create-auctions), [report-events](https://docs.topsort.com/en/api-reference/events/report-events), and [create-sponsored-brand-auctions](https://docs.topsort.com/en/api-reference/auctions/create-sponsored-brand-auctions). Correct purchase attribution requires a long-lived, consistent opaque user ID between auction and event requests.
- Adds optional `page` to `AuctionBase`, reusing the existing `Page` type (`StandardPage | CartPage`) already exported for events. The auctions docs list this field as optional across all auction types.
- No changes to existing event types — a review confirmed they already match the latest report-events schema (incl. `opaqueUserId`, `resolvedBidId`, `additionalAttribution`, `placement`, `object`, `page`, `externalCampaignId`, `externalVendorId`, `deviceType`, `channel`, etc.).
- Sponsored brand auctions are a separate endpoint not currently implemented by this SDK — the scope of this PR is field alignment with the existing auctions endpoint.

## Test plan

- [x] `bun test` — all 21 tests pass, including a new case exercising `opaqueUserId` and `page` (both `StandardPage` and `CartPage` variants) on listings and banner auctions
- [x] `bun run format` — Biome clean
- [x] `tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)