### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topsort/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "The official Topsort SDK for TypeScript and JavaScript",
   "packageManager": "bun@1.3.3",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

- Patch bump `@topsort/sdk` from `0.4.0` to `0.4.1`.
- Ships the `opaqueUserId` and `page` additions on auction requests merged in #232.

## Test plan

- [x] No code changes beyond `package.json` version field

🤖 Generated with [Claude Code](https://claude.com/claude-code)