### PR TITLE
ci: harden npm publish token scope

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
 
       - name: Run tests
         run: bun test


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` from the `actions/setup-node` step in the npm release workflow.
- Keep package publishing credentials scoped to the `npm publish` step, which already uses provenance and public access flags.

## Test plan
- `actionlint -color .github/workflows/publish-to-npm.yml` using actionlint v1.7.11
- `git diff --check`
- Cursor lints for `.github/workflows/publish-to-npm.yml`


Made with [Cursor](https://cursor.com)