### PR TITLE
chore(ci): remove codecov integration

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,8 +1,0 @@
-comment: false
-
-coverage:
-  status:
-    project:
-      default:
-        target: 100%
-    patch: off

--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -19,23 +19,7 @@ jobs:
       - run: bun install
 
       - name: Run tests
-        run: bun test --reporter=junit --reporter-outfile=tests.xml --coverage --coverage-reporter=lcov --coverage-dir=coverage
-
-      - uses: codecov/codecov-action@v5.5.4
-        with:
-          slug: Topsort/topsort.js
-          files: coverage/lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unittest
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          slug: Topsort/topsort.js
-          files: tests.xml
-
+        run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage
 
   bun-test-e2e:
     name: E2E Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,6 @@ topsort.js is the official `@topsort/sdk` -- a fully typed TypeScript client for
 | Linting/Formatting | [Biome](https://biomejs.dev/) (v2)                      |
 | Git hooks        | [Lefthook](https://github.com/evilmartians/lefthook)      |
 | CI               | GitHub Actions                                             |
-| Code coverage    | [Codecov](https://codecov.io/)                             |
 
 ## Key Commands
 
@@ -102,7 +101,7 @@ dist/                             # Build output (gitignored)
 - Location: `test/` directory.
 - HTTP mocking: [MSW](https://mswjs.io/) (Mock Service Worker) with handlers in `src/constants/handlers.constant.ts`.
 - Run: `bun test`.
-- Coverage: Built-in Bun coverage (`--coverage`), reported to Codecov in CI.
+- Coverage: Built-in Bun coverage (`--coverage`).
 - Pattern: Each test file mirrors a source module. Use `describe`/`it` blocks. Set up MSW server in `beforeAll`, reset handlers in `afterEach`.
 
 ### E2E Tests
@@ -126,7 +125,7 @@ dist/                             # Build output (gitignored)
 
 | Workflow                  | Trigger (paths)            | What it does                                       |
 | ------------------------- | -------------------------- | -------------------------------------------------- |
-| **Bun** (test-bun.yml)   | `**/*.ts`, `./bun.lockb`  | Runs unit tests + Codecov upload; runs E2E tests   |
+| **Bun** (test-bun.yml)   | `**/*.ts`, `./bun.lockb`  | Runs unit tests; runs E2E tests   |
 | **Biome** (validate-biome.yml) | `**/*.ts`, `**/*.json` | Runs `biome ci` on changed files                   |
 | **Conventional Commits** (validate-convco.yml) | All PRs | Validates PR title matches Conventional Commits    |
 | **Typos** (validate-typos.yml) | `**/*.md`             | Spell-checks Markdown files                        |


### PR DESCRIPTION
We weren't really using this and the recent changes in ownership made us to reassess the usage of Codecov.