### PR TITLE
test: await async expect assertions in web and react-native tests

### DIFF
--- a/packages/react-native/test/api-client.test.ts
+++ b/packages/react-native/test/api-client.test.ts
@@ -18,7 +18,7 @@ describe("apiClient", () => {
     };
     returnAuctionSuccess(`${baseURL}/${endpoints.auctions}`);
 
-    expect(apiClient.post(customURL, {} as Event, config)).resolves.toEqual({
+    await expect(apiClient.post(customURL, {} as Event, config)).resolves.toEqual({
       results: [
         {
           resultType: "listings",

--- a/packages/react-native/test/auctions.test.ts
+++ b/packages/react-native/test/auctions.test.ts
@@ -18,7 +18,7 @@ describe("createAuction", () => {
 
   it("should handle authentication error", async () => {
     returnStatus(401, `${baseURL}/${endpoints.auctions}`);
-    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -28,7 +28,7 @@ describe("createAuction", () => {
 
   it("should handle retryable error", async () => {
     returnStatus(429, `${baseURL}/${endpoints.auctions}`);
-    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 429,
       retry: true,
       statusText: "Too Many Requests",
@@ -38,7 +38,7 @@ describe("createAuction", () => {
 
   it("should handle server error", async () => {
     returnStatus(500, `${baseURL}/${endpoints.auctions}`);
-    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 500,
       retry: true,
       statusText: "Internal Server Error",
@@ -53,7 +53,7 @@ describe("createAuction", () => {
       host: "https://demo.api.topsort.com",
     });
 
-    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",
@@ -88,7 +88,7 @@ describe("createAuction", () => {
       timeout: 50,
     });
 
-    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",
@@ -112,7 +112,7 @@ describe("createAuction", () => {
       fetchOptions: { cache: "no-cache" },
     });
 
-    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",

--- a/packages/react-native/test/events.test.ts
+++ b/packages/react-native/test/events.test.ts
@@ -13,7 +13,7 @@ describe("reportEvent", () => {
 
   it("should handle authentication error", async () => {
     returnStatus(401, `${baseURL}/${endpoints.events}`);
-    expect(topsortClient.reportEvent({} as Event)).rejects.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -23,7 +23,7 @@ describe("reportEvent", () => {
 
   it("should handle retryable error", async () => {
     returnStatus(429, `${baseURL}/${endpoints.events}`);
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: false,
       retry: true,
     });
@@ -31,7 +31,7 @@ describe("reportEvent", () => {
 
   it("should handle server error", async () => {
     returnStatus(500, `${baseURL}/${endpoints.events}`);
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: false,
       retry: true,
     });
@@ -44,7 +44,7 @@ describe("reportEvent", () => {
       host: "https://demo.api.topsort.com",
     });
 
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: true,
       retry: false,
     });
@@ -69,7 +69,7 @@ describe("reportEvent", () => {
       fetchOptions: { cache: "no-cache" },
     });
 
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: true,
       retry: false,
     });
@@ -94,7 +94,7 @@ describe("reportEvent", () => {
       ],
     };
 
-    expect(topsortClient.reportEvent(pageviewEvent)).resolves.toEqual({
+    await expect(topsortClient.reportEvent(pageviewEvent)).resolves.toEqual({
       ok: true,
       retry: false,
     });

--- a/packages/web/test/api-client.test.ts
+++ b/packages/web/test/api-client.test.ts
@@ -18,7 +18,7 @@ describe("apiClient", () => {
     };
     returnAuctionSuccess(`${baseURL}/${endpoints.auctions}`);
 
-    expect(apiClient.post(customURL, {} as Event, config)).resolves.toEqual({
+    await expect(apiClient.post(customURL, {} as Event, config)).resolves.toEqual({
       results: [
         {
           resultType: "listings",

--- a/packages/web/test/auctions.test.ts
+++ b/packages/web/test/auctions.test.ts
@@ -18,7 +18,7 @@ describe("createAuction", () => {
 
   it("should handle authentication error", async () => {
     returnStatus(401, `${baseURL}/${endpoints.auctions}`);
-    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -28,7 +28,7 @@ describe("createAuction", () => {
 
   it("should handle retryable error", async () => {
     returnStatus(429, `${baseURL}/${endpoints.auctions}`);
-    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 429,
       retry: true,
       statusText: "Too Many Requests",
@@ -38,7 +38,7 @@ describe("createAuction", () => {
 
   it("should handle server error", async () => {
     returnStatus(500, `${baseURL}/${endpoints.auctions}`);
-    expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).rejects.toEqual({
       status: 500,
       retry: true,
       statusText: "Internal Server Error",
@@ -53,7 +53,7 @@ describe("createAuction", () => {
       host: "https://demo.api.topsort.com",
     });
 
-    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",
@@ -88,7 +88,7 @@ describe("createAuction", () => {
       timeout: 50,
     });
 
-    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",
@@ -112,7 +112,7 @@ describe("createAuction", () => {
       fetchOptions: { keepalive: false, cache: "no-cache" },
     });
 
-    expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction({} as Auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",
@@ -149,7 +149,7 @@ describe("createAuction", () => {
       ],
     };
 
-    expect(topsortClient.createAuction(auction)).resolves.toEqual({
+    await expect(topsortClient.createAuction(auction)).resolves.toEqual({
       results: [
         {
           resultType: "listings",

--- a/packages/web/test/events.test.ts
+++ b/packages/web/test/events.test.ts
@@ -13,7 +13,7 @@ describe("reportEvent", () => {
 
   it("should handle authentication error", async () => {
     returnStatus(401, `${baseURL}/${endpoints.events}`);
-    expect(topsortClient.reportEvent({} as Event)).rejects.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).rejects.toEqual({
       status: 401,
       retry: false,
       statusText: "Unauthorized",
@@ -23,7 +23,7 @@ describe("reportEvent", () => {
 
   it("should handle retryable error", async () => {
     returnStatus(429, `${baseURL}/${endpoints.events}`);
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: false,
       retry: true,
     });
@@ -31,7 +31,7 @@ describe("reportEvent", () => {
 
   it("should handle server error", async () => {
     returnStatus(500, `${baseURL}/${endpoints.events}`);
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: false,
       retry: true,
     });
@@ -44,7 +44,7 @@ describe("reportEvent", () => {
       host: "https://demo.api.topsort.com",
     });
 
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: true,
       retry: false,
     });
@@ -69,7 +69,7 @@ describe("reportEvent", () => {
       fetchOptions: { keepalive: false, cache: "no-cache" },
     });
 
-    expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
+    await expect(topsortClient.reportEvent({} as Event)).resolves.toEqual({
       ok: true,
       retry: false,
     });
@@ -94,7 +94,7 @@ describe("reportEvent", () => {
       ],
     };
 
-    expect(topsortClient.reportEvent(pageviewEvent)).resolves.toEqual({
+    await expect(topsortClient.reportEvent(pageviewEvent)).resolves.toEqual({
       ok: true,
       retry: false,
     });
@@ -119,7 +119,7 @@ describe("reportEvent", () => {
       ],
     };
 
-    expect(topsortClient.reportEvent(cartPageviewEvent)).resolves.toEqual({
+    await expect(topsortClient.reportEvent(cartPageviewEvent)).resolves.toEqual({
       ok: true,
       retry: false,
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses review feedback on floating promise assertions in `packages/react-native/test/events.test.ts`.

Under `bun:test`, unawaited `expect(...).rejects` / `expect(...).resolves` assertions can let failing expectations pass silently. This adds `await` to all async assertions in both packages while touching the tests:

- `packages/react-native/test/{events,auctions,api-client}.test.ts`
- `packages/web/test/{events,auctions,api-client}.test.ts`

Web package unit tests pass locally (`bun test` on the web test files).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-952e9139-bd68-45aa-9d53-4f15e731e97a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-952e9139-bd68-45aa-9d53-4f15e731e97a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

