### PR TITLE
fix: ship react-native url polyfill as a runtime dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,13 +19,14 @@
     "packages/react-native": {
       "name": "@topsort/react-native-sdk",
       "version": "0.4.1",
+      "dependencies": {
+        "react-native-url-polyfill": "^2.0.0",
+      },
       "devDependencies": {
         "@topsort/sdk-core": "workspace:*",
-        "react-native-url-polyfill": "^2.0.0",
       },
       "peerDependencies": {
         "react-native": ">=0.70.0",
-        "react-native-url-polyfill": ">=2.0.0",
       },
     },
     "packages/web": {

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,12 +4,10 @@ Official [Topsort](https://topsort.com) SDK for React Native. Same `createAuctio
 
 ## Installation
 
-Install the SDK and its peer dependencies:
-
 ```sh
-npm install @topsort/react-native-sdk react-native-url-polyfill
+npm install @topsort/react-native-sdk
 # or
-yarn add @topsort/react-native-sdk react-native-url-polyfill
+yarn add @topsort/react-native-sdk
 ```
 
 Peer requirements:
@@ -17,11 +15,10 @@ Peer requirements:
 | Package | Version |
 | --- | --- |
 | `react-native` | `>=0.70.0` |
-| `react-native-url-polyfill` | `>=2.0.0` |
 
 ### Why `react-native-url-polyfill`?
 
-The shared core sanitizes every request URL with `new URL()` before calling `fetch`. React Native's built-in `URL` is incomplete and can misbehave on trailing-slash normalization. The SDK imports the polyfill automatically when you load the transport, but **you must install the peer dependency** so Metro can resolve it.
+The shared core sanitizes every request URL with `new URL()` before calling `fetch`. React Native's built-in `URL` is incomplete and can misbehave on trailing-slash normalization. The SDK depends on `react-native-url-polyfill` and imports it automatically when you load the transport — no separate install step.
 
 ## Usage
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,14 +42,14 @@
     "test": "bun test",
     "test:harness": "bun run build && bun test ./harness/smoke.test.ts"
   },
-  "dependencies": {},
-  "devDependencies": {
-    "@topsort/sdk-core": "workspace:*",
+  "dependencies": {
     "react-native-url-polyfill": "^2.0.0"
   },
+  "devDependencies": {
+    "@topsort/sdk-core": "workspace:*"
+  },
   "peerDependencies": {
-    "react-native": ">=0.70.0",
-    "react-native-url-polyfill": ">=2.0.0"
+    "react-native": ">=0.70.0"
   },
   "keywords": [
     "topsort",


### PR DESCRIPTION
## Summary

**Resolves:** https://topsort.atlassian.net/browse/INTE-2605

Follow-up to #243. The RN SDK unconditionally imports `react-native-url-polyfill/auto`, but the package was only a `peerDependency`, so installs of `@topsort/react-native-sdk` alone can fail Metro resolution unless consumers also installed the polyfill.

- Move `react-native-url-polyfill` from `peerDependencies` / `devDependencies` to `dependencies`
- Keep `react-native` as the only peer
- Update the RN README install instructions

## Test plan

- [ ] `bun install`
- [ ] `bun run --cwd packages/react-native test`
- [ ] Confirm package consumers get the polyfill without a separate install

**Reviewers:** @barbmarcio 

