### PR TITLE
feat: add durable React Native offline event queue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,15 +18,23 @@
     },
     "packages/react-native": {
       "name": "@topsort/react-native-sdk",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "devDependencies": {
         "@topsort/sdk-core": "workspace:*",
         "react-native-url-polyfill": "^2.0.0",
       },
       "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.17.0",
+        "@react-native-community/netinfo": ">=9.0.0",
         "react-native": ">=0.70.0",
+        "react-native-mmkv": ">=2.0.0",
         "react-native-url-polyfill": ">=2.0.0",
       },
+      "optionalPeers": [
+        "@react-native-async-storage/async-storage",
+        "@react-native-community/netinfo",
+        "react-native-mmkv",
+      ],
     },
     "packages/web": {
       "name": "@topsort/sdk",

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,10 +1,10 @@
 # @topsort/react-native-sdk
 
-Official [Topsort](https://topsort.com) SDK for React Native. Same `createAuction` and `reportEvent` API as [`@topsort/sdk`](../web/README.md), with a React Native fetch transport (no `keepalive`, RN-appropriate defaults).
+Official [Topsort](https://topsort.com) SDK for React Native. Same `createAuction` and `reportEvent` API as [`@topsort/sdk`](../web/README.md), with a React Native fetch transport (no `keepalive`) and an **opt-in durable offline event queue**.
 
 ## Installation
 
-Install the SDK and its peer dependencies:
+Install the SDK and its required peer dependencies:
 
 ```sh
 npm install @topsort/react-native-sdk react-native-url-polyfill
@@ -12,12 +12,13 @@ npm install @topsort/react-native-sdk react-native-url-polyfill
 yarn add @topsort/react-native-sdk react-native-url-polyfill
 ```
 
-Peer requirements:
-
-| Package | Version |
-| --- | --- |
-| `react-native` | `>=0.70.0` |
-| `react-native-url-polyfill` | `>=2.0.0` |
+| Package | Version | Required |
+| --- | --- | --- |
+| `react-native` | `>=0.70.0` | yes |
+| `react-native-url-polyfill` | `>=2.0.0` | yes |
+| `@react-native-async-storage/async-storage` | `>=1.17.0` | only if you enable `offlineQueue` without a custom `storage` |
+| `@react-native-community/netinfo` | `>=9.0.0` | recommended with `offlineQueue` (reconnect flush) |
+| `react-native-mmkv` | `>=2.0.0` | optional encrypted storage adapter |
 
 ### Why `react-native-url-polyfill`?
 
@@ -32,12 +33,11 @@ const client = new TopsortClient({
   apiKey: "TSE_your_api_key",
 });
 
-// Auctions
 const auction = await client.createAuction({
   auctions: [{ type: "listings", slots: 3, products: { ids: ["p_1"] } }],
 });
 
-// Events (429 / 5xx return { ok: false, retry: true } instead of throwing)
+// Without offlineQueue: 429 / 5xx return { ok: false, retry: true } (same as web).
 const result = await client.reportEvent({
   impressions: [
     {
@@ -52,9 +52,67 @@ const result = await client.reportEvent({
 
 See the [web SDK README](../web/README.md) for full auction and event payload shapes.
 
+## Offline event queue
+
+This is the React Native analog of the web SDK's `keepalive` default: events that fail with a **retryable** core signal (`{ ok: false, retry: true }` for HTTP 429/5xx) or a **network/transport** failure are persisted locally and flushed when connectivity returns or the app transitions through `AppState` `active` / `background`.
+
+Design follows [topsort.kt](https://github.com/Topsort/topsort.kt): persist under a record id → deferred connectivity-gated send → delete on success or permanent 4xx; retry with backoff on transient failure.
+
+### Enable (opt-in — non-breaking)
+
+```ts
+import {
+  TopsortClient,
+  createAsyncStorageAdapter,
+  createMMKVStorageAdapter,
+} from "@topsort/react-native-sdk";
+
+// Default AsyncStorage adapter (plaintext)
+const client = new TopsortClient({
+  apiKey: "TSE_your_api_key",
+  offlineQueue: true,
+});
+
+// Preferred encrypted posture (MMKV encryption key) — closest to Android EncryptedSharedPreferences
+const encrypted = new TopsortClient({
+  apiKey: "TSE_your_api_key",
+  offlineQueue: {
+    storage: createMMKVStorageAdapter({ encryptionKey: "your-32-byte-secret-key!!!!" }),
+    maxSize: 1000,
+    dropPolicy: "oldest", // or "newest"
+    maxAttempts: 10,
+  },
+});
+
+await client.whenReady();
+await client.flush(); // optional manual flush
+client.dispose(); // unsubscribe AppState / NetInfo
+```
+
+With the queue enabled:
+
+| Core outcome | RN client behavior |
+| --- | --- |
+| `{ ok: true }` | unchanged |
+| `{ ok: false, retry: true }` | enqueued; resolves `{ ok: true, retry: false }` (SDK owns retry) |
+| Thrown 4xx (`AppError`, e.g. 401) | not enqueued; still throws |
+| Network / transport failure | enqueued; resolves `{ ok: true, retry: false }` |
+
+When `offlineQueue` is omitted, behavior matches `@topsort/sdk` / Phase 2 exactly.
+
+### Storage adapters
+
+| Helper | Notes |
+| --- | --- |
+| `createAsyncStorageAdapter()` | Default when `offlineQueue: true` |
+| `createMMKVStorageAdapter({ encryptionKey })` | Encrypted cache option |
+| `createMemoryStorageAdapter()` | Tests / ephemeral |
+
+You can also pass any object implementing `EventStorageAdapter` (`getItem` / `setItem` / `removeItem` / `getAllKeys`).
+
 ## Versioning
 
-Each package has its own `version` in `packages/web/package.json` and `packages/react-native/package.json`. Versions are independent — bump only the package(s) you are releasing. On a GitHub release, the publish workflow publishes each package only when that version is not already on npm, so a web-only bump (e.g. `@topsort/sdk@0.4.2`) does not fail when `@topsort/react-native-sdk` is still at `0.4.1`.
+Each package has its own `version` in `packages/web/package.json` and `packages/react-native/package.json`. Versions are independent — bump only the package(s) you are releasing. On a GitHub release, the publish workflow publishes each package only when that version is not already on npm.
 
 ## License
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -98,7 +98,9 @@ With the queue enabled:
 | Thrown 4xx (`AppError`, e.g. 401) | not enqueued; still throws |
 | Network / transport failure | enqueued; resolves `{ ok: true, retry: false }` |
 
-When `offlineQueue` is omitted, behavior matches `@topsort/sdk` / Phase 2 exactly.
+When the durable backlog is non-empty, new events are enqueued (and flushed) instead of jumping ahead with a live send — FIFO drain matching Android’s durable queue.
+
+When `offlineQueue` is omitted, behavior matches `@topsort/sdk` / Phase 2 exactly. Queue wiring is best-effort: a flaky NetInfo/AppState peer will not take down `reportEvent`.
 
 ### Storage adapters
 

--- a/packages/react-native/bunup.config.ts
+++ b/packages/react-native/bunup.config.ts
@@ -10,4 +10,13 @@ export default defineConfig({
   minify: true,
   format: ["esm", "cjs"],
   noExternal: ["@topsort/sdk-core"],
+  // Optional peers / RN runtime — resolved by Metro at app runtime.
+  external: [
+    "react-native",
+    "react-native-url-polyfill",
+    "react-native-url-polyfill/auto",
+    "@react-native-async-storage/async-storage",
+    "@react-native-community/netinfo",
+    "react-native-mmkv",
+  ],
 });

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topsort/react-native-sdk",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "The official Topsort SDK for React Native",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -48,13 +48,28 @@
     "react-native-url-polyfill": "^2.0.0"
   },
   "peerDependencies": {
+    "@react-native-async-storage/async-storage": ">=1.17.0",
+    "@react-native-community/netinfo": ">=9.0.0",
     "react-native": ">=0.70.0",
+    "react-native-mmkv": ">=2.0.0",
     "react-native-url-polyfill": ">=2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    },
+    "@react-native-community/netinfo": {
+      "optional": true
+    },
+    "react-native-mmkv": {
+      "optional": true
+    }
   },
   "keywords": [
     "topsort",
     "sdk",
     "react-native",
-    "typescript"
+    "typescript",
+    "offline"
   ]
 }

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,3 +1,18 @@
 export { AppError } from "@topsort/sdk-core";
+export type {
+  AppStateSource,
+  ConnectivitySource,
+  DropPolicy,
+  EventStorageAdapter,
+  MMKVStorageOptions,
+  OfflineQueueOptions,
+  QueueRecord,
+} from "./queue";
+export {
+  createAsyncStorageAdapter,
+  createMemoryStorageAdapter,
+  createMMKVStorageAdapter,
+  MemoryStorageAdapter,
+} from "./queue";
 export { TopsortClient } from "./topsort-client";
 export type * from "./types";

--- a/packages/react-native/src/queue/backoff.ts
+++ b/packages/react-native/src/queue/backoff.ts
@@ -1,0 +1,13 @@
+/** Exponential backoff with jitter, capped at 5 minutes (mirrors WorkManager-style retry). */
+const BASE_MS = 1_000;
+const MAX_MS = 5 * 60 * 1_000;
+
+export function nextAttemptDelayMs(attempts: number): number {
+  const exp = Math.min(MAX_MS, BASE_MS * 2 ** Math.max(0, attempts - 1));
+  const jitter = Math.floor(Math.random() * Math.min(1_000, exp * 0.2));
+  return Math.min(MAX_MS, exp + jitter);
+}
+
+export function nextAttemptAt(attempts: number, now: number = Date.now()): number {
+  return now + nextAttemptDelayMs(attempts);
+}

--- a/packages/react-native/src/queue/event-queue.ts
+++ b/packages/react-native/src/queue/event-queue.ts
@@ -52,7 +52,8 @@ export class EventQueue {
   }
 
   async size(): Promise<number> {
-    return (await this.loadRecordIds()).length;
+    // loadRecordIds may migrate/write the index — must not race with enqueue/persist.
+    return this.withWriteLock(async () => (await this.loadRecordIds()).length);
   }
 
   async enqueue(event: Event): Promise<QueueRecord> {
@@ -212,6 +213,9 @@ export class EventQueue {
   /**
    * Prefer the dedicated index; migrate once from `getAllKeys()` when absent
    * (legacy installs / first AsyncStorage scan).
+   *
+   * Callers that may trigger migration must hold {@link withWriteLock} so a stale
+   * scan cannot overwrite a concurrent enqueue's index and orphan records.
    */
   private async loadRecordIds(): Promise<string[]> {
     const raw = await this.storage.getItem(QUEUE_INDEX_KEY);

--- a/packages/react-native/src/queue/event-queue.ts
+++ b/packages/react-native/src/queue/event-queue.ts
@@ -1,0 +1,209 @@
+import type { Event, EventResult } from "@topsort/sdk-core";
+import { nextAttemptAt } from "./backoff";
+import {
+  type DropPolicy,
+  type EventStorageAdapter,
+  isRecordStorageKey,
+  type QueueRecord,
+  recordStorageKey,
+} from "./types";
+
+export type SendEvent = (event: Event) => Promise<EventResult>;
+
+export interface EventQueueOptions {
+  storage: EventStorageAdapter;
+  maxSize: number;
+  dropPolicy: DropPolicy;
+  maxAttempts: number;
+  send: SendEvent;
+  /** Injected for tests. */
+  now?: () => number;
+  /** Injected for tests. */
+  createId?: () => string;
+}
+
+/**
+ * Durable event queue modeled on topsort.kt Cache + EventEmitterWorker:
+ * persist under a record id, delete on success / permanent failure, retry on transient.
+ */
+export class EventQueue {
+  private readonly storage: EventStorageAdapter;
+  private readonly maxSize: number;
+  private readonly dropPolicy: DropPolicy;
+  private readonly maxAttempts: number;
+  private readonly send: SendEvent;
+  private readonly now: () => number;
+  private readonly createId: () => string;
+  private flushPromise: Promise<{ sent: number; remaining: number }> | null = null;
+
+  constructor(options: EventQueueOptions) {
+    this.storage = options.storage;
+    this.maxSize = options.maxSize;
+    this.dropPolicy = options.dropPolicy;
+    this.maxAttempts = options.maxAttempts;
+    this.send = options.send;
+    this.now = options.now ?? Date.now;
+    this.createId =
+      options.createId ?? (() => `${this.now()}-${Math.random().toString(36).slice(2)}`);
+  }
+
+  async size(): Promise<number> {
+    return (await this.loadRecords()).length;
+  }
+
+  async enqueue(event: Event): Promise<QueueRecord> {
+    const records = await this.loadRecords();
+    await this.enforceCap(records);
+
+    if (this.dropPolicy === "newest" && records.length >= this.maxSize) {
+      // Cap full and dropping newest means reject this enqueue.
+      throw new Error("@topsort/react-native-sdk: offline queue is full (dropPolicy: newest)");
+    }
+
+    const record: QueueRecord = {
+      id: this.createId(),
+      event,
+      enqueuedAt: new Date(this.now()).toISOString(),
+      attempts: 0,
+      nextAttemptAt: this.now(),
+    };
+
+    await this.persist(record);
+    return record;
+  }
+
+  /** Flush due records oldest-first. Concurrent callers await the in-flight flush. */
+  async flush(): Promise<{ sent: number; remaining: number }> {
+    if (this.flushPromise) {
+      return this.flushPromise;
+    }
+
+    this.flushPromise = this.runFlush().finally(() => {
+      this.flushPromise = null;
+    });
+    return this.flushPromise;
+  }
+
+  private async runFlush(): Promise<{ sent: number; remaining: number }> {
+    let sent = 0;
+    const records = (await this.loadRecords()).sort(
+      (a, b) => Date.parse(a.enqueuedAt) - Date.parse(b.enqueuedAt),
+    );
+    const now = this.now();
+
+    for (const record of records) {
+      if (record.nextAttemptAt > now) {
+        continue;
+      }
+
+      const outcome = await this.attempt(record);
+      if (outcome === "sent") {
+        sent += 1;
+      }
+    }
+
+    return { sent, remaining: await this.size() };
+  }
+
+  private async attempt(record: QueueRecord): Promise<"sent" | "retry" | "dropped"> {
+    try {
+      const result = await this.send(record.event);
+
+      if (result.ok) {
+        await this.remove(record.id);
+        return "sent";
+      }
+
+      if (result.retry) {
+        return await this.scheduleRetry(record);
+      }
+
+      // Non-retryable EventResult (should be rare) — drop like Android PERMANENT_FAILURE.
+      await this.remove(record.id);
+      return "dropped";
+    } catch (error) {
+      if (isPermanentFailure(error)) {
+        await this.remove(record.id);
+        return "dropped";
+      }
+      return await this.scheduleRetry(record);
+    }
+  }
+
+  private async scheduleRetry(record: QueueRecord): Promise<"retry" | "dropped"> {
+    const attempts = record.attempts + 1;
+    if (attempts >= this.maxAttempts) {
+      await this.remove(record.id);
+      return "dropped";
+    }
+
+    const updated: QueueRecord = {
+      ...record,
+      attempts,
+      nextAttemptAt: nextAttemptAt(attempts, this.now()),
+    };
+    await this.persist(updated);
+    return "retry";
+  }
+
+  private async enforceCap(records: QueueRecord[]): Promise<void> {
+    if (this.dropPolicy !== "oldest") {
+      return;
+    }
+
+    while (records.length >= this.maxSize) {
+      const sorted = [...records].sort(
+        (a, b) => Date.parse(a.enqueuedAt) - Date.parse(b.enqueuedAt),
+      );
+      const victim = sorted[0];
+      if (!victim) {
+        break;
+      }
+      await this.remove(victim.id);
+      const index = records.findIndex((record) => record.id === victim.id);
+      if (index >= 0) {
+        records.splice(index, 1);
+      }
+    }
+  }
+
+  private async loadRecords(): Promise<QueueRecord[]> {
+    const keys = (await this.storage.getAllKeys()).filter(isRecordStorageKey);
+    const records: QueueRecord[] = [];
+
+    for (const key of keys) {
+      const raw = await this.storage.getItem(key);
+      if (!raw) {
+        continue;
+      }
+      try {
+        records.push(JSON.parse(raw) as QueueRecord);
+      } catch {
+        await this.storage.removeItem(key);
+      }
+    }
+
+    return records;
+  }
+
+  private async persist(record: QueueRecord): Promise<void> {
+    await this.storage.setItem(recordStorageKey(record.id), JSON.stringify(record));
+  }
+
+  private async remove(id: string): Promise<void> {
+    await this.storage.removeItem(recordStorageKey(id));
+  }
+}
+
+function isPermanentFailure(error: unknown): boolean {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof (error as { status: unknown }).status === "number"
+  ) {
+    const status = (error as { status: number }).status;
+    return status >= 400 && status < 500;
+  }
+  return false;
+}

--- a/packages/react-native/src/queue/event-queue.ts
+++ b/packages/react-native/src/queue/event-queue.ts
@@ -4,6 +4,8 @@ import {
   type DropPolicy,
   type EventStorageAdapter,
   isRecordStorageKey,
+  QUEUE_INDEX_KEY,
+  QUEUE_KEY_PREFIX,
   type QueueRecord,
   recordStorageKey,
 } from "./types";
@@ -50,7 +52,7 @@ export class EventQueue {
   }
 
   async size(): Promise<number> {
-    return (await this.loadRecords()).length;
+    return (await this.loadRecordIds()).length;
   }
 
   async enqueue(event: Event): Promise<QueueRecord> {
@@ -189,30 +191,68 @@ export class EventQueue {
   }
 
   private async loadRecords(): Promise<QueueRecord[]> {
-    const keys = (await this.storage.getAllKeys()).filter(isRecordStorageKey);
+    const ids = await this.loadRecordIds();
     const records: QueueRecord[] = [];
 
-    for (const key of keys) {
-      const raw = await this.storage.getItem(key);
+    for (const id of ids) {
+      const raw = await this.storage.getItem(recordStorageKey(id));
       if (!raw) {
         continue;
       }
       try {
         records.push(JSON.parse(raw) as QueueRecord);
       } catch {
-        await this.storage.removeItem(key);
+        await this.storage.removeItem(recordStorageKey(id));
       }
     }
 
     return records;
   }
 
+  /**
+   * Prefer the dedicated index; migrate once from `getAllKeys()` when absent
+   * (legacy installs / first AsyncStorage scan).
+   */
+  private async loadRecordIds(): Promise<string[]> {
+    const raw = await this.storage.getItem(QUEUE_INDEX_KEY);
+    if (raw != null) {
+      try {
+        const ids = JSON.parse(raw) as unknown;
+        if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
+          return ids;
+        }
+      } catch {
+        // Fall through to migrate from a full key scan.
+      }
+    }
+
+    const keys = (await this.storage.getAllKeys()).filter(isRecordStorageKey);
+    const ids = keys.map((key) => key.slice(QUEUE_KEY_PREFIX.length));
+    await this.writeIndex(ids);
+    return ids;
+  }
+
+  private async writeIndex(ids: string[]): Promise<void> {
+    if (ids.length === 0) {
+      await this.storage.removeItem(QUEUE_INDEX_KEY);
+      return;
+    }
+    await this.storage.setItem(QUEUE_INDEX_KEY, JSON.stringify(ids));
+  }
+
   private async persist(record: QueueRecord): Promise<void> {
     await this.storage.setItem(recordStorageKey(record.id), JSON.stringify(record));
+    const ids = await this.loadRecordIds();
+    if (!ids.includes(record.id)) {
+      ids.push(record.id);
+      await this.writeIndex(ids);
+    }
   }
 
   private async remove(id: string): Promise<void> {
     await this.storage.removeItem(recordStorageKey(id));
+    const ids = (await this.loadRecordIds()).filter((existing) => existing !== id);
+    await this.writeIndex(ids);
   }
 }
 

--- a/packages/react-native/src/queue/event-queue.ts
+++ b/packages/react-native/src/queue/event-queue.ts
@@ -39,6 +39,8 @@ export class EventQueue {
   private flushPromise: Promise<{ sent: number; remaining: number }> | null = null;
   /** Serializes mutate paths so concurrent enqueues cannot bypass maxSize. */
   private writeChain: Promise<unknown> = Promise.resolve();
+  /** One getAllKeys pass per instance to recover records orphaned by a mid-write crash. */
+  private didReconcileOrphans = false;
 
   constructor(options: EventQueueOptions) {
     this.storage = options.storage;
@@ -52,31 +54,48 @@ export class EventQueue {
   }
 
   async size(): Promise<number> {
-    // loadRecordIds may migrate/write the index — must not race with enqueue/persist.
-    return this.withWriteLock(async () => (await this.loadRecordIds()).length);
+    // loadRecords may migrate/prune/write the index — must not race with enqueue/persist.
+    return this.withWriteLock(async () => (await this.loadRecords()).length);
   }
 
   async enqueue(event: Event): Promise<QueueRecord> {
+    return this.withWriteLock(async () => this.enqueueUnlocked(event));
+  }
+
+  /**
+   * Atomically enqueue only when a backlog already exists (FIFO path).
+   * Returns `null` when the queue is empty so the caller can live-send.
+   */
+  async enqueueIfBacklog(event: Event): Promise<QueueRecord | null> {
     return this.withWriteLock(async () => {
+      // Use loadRecords (not raw ids) so phantom index entries don't look like backlog.
       const records = await this.loadRecords();
-      await this.enforceCap(records);
-
-      if (this.dropPolicy === "newest" && records.length >= this.maxSize) {
-        // Cap full and dropping newest means reject this enqueue.
-        throw new Error("@topsort/react-native-sdk: offline queue is full (dropPolicy: newest)");
+      if (records.length === 0) {
+        return null;
       }
-
-      const record: QueueRecord = {
-        id: this.createId(),
-        event,
-        enqueuedAt: new Date(this.now()).toISOString(),
-        attempts: 0,
-        nextAttemptAt: this.now(),
-      };
-
-      await this.persist(record);
-      return record;
+      return this.enqueueUnlocked(event);
     });
+  }
+
+  private async enqueueUnlocked(event: Event): Promise<QueueRecord> {
+    const records = await this.loadRecords();
+    await this.enforceCap(records);
+
+    if (this.dropPolicy === "newest" && records.length >= this.maxSize) {
+      // Cap full and dropping newest means reject this enqueue.
+      throw new Error("@topsort/react-native-sdk: offline queue is full (dropPolicy: newest)");
+    }
+
+    const record: QueueRecord = {
+      id: this.createId(),
+      event,
+      enqueuedAt: new Date(this.now()).toISOString(),
+      attempts: 0,
+      nextAttemptAt: this.now(),
+    };
+
+    await this.persist(record);
+    return record;
   }
 
   private async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -194,17 +213,24 @@ export class EventQueue {
   private async loadRecords(): Promise<QueueRecord[]> {
     const ids = await this.loadRecordIds();
     const records: QueueRecord[] = [];
+    const livingIds: string[] = [];
 
     for (const id of ids) {
       const raw = await this.storage.getItem(recordStorageKey(id));
       if (!raw) {
+        // Phantom index entry (e.g. crash after delete, before index write).
         continue;
       }
       try {
         records.push(JSON.parse(raw) as QueueRecord);
+        livingIds.push(id);
       } catch {
         await this.storage.removeItem(recordStorageKey(id));
       }
+    }
+
+    if (livingIds.length !== ids.length) {
+      await this.writeIndex(livingIds);
     }
 
     return records;
@@ -223,7 +249,7 @@ export class EventQueue {
       try {
         const ids = JSON.parse(raw) as unknown;
         if (Array.isArray(ids) && ids.every((id) => typeof id === "string")) {
-          return ids;
+          return this.reconcileOrphansOnce(ids);
         }
       } catch {
         // Fall through to migrate from a full key scan.
@@ -232,8 +258,40 @@ export class EventQueue {
 
     const keys = (await this.storage.getAllKeys()).filter(isRecordStorageKey);
     const ids = keys.map((key) => key.slice(QUEUE_KEY_PREFIX.length));
+    this.didReconcileOrphans = true;
     await this.writeIndex(ids);
     return ids;
+  }
+
+  /**
+   * Recover record bodies written before a crash that prevented the index update.
+   * Runs at most once per queue instance so steady-state ops stay O(index).
+   */
+  private async reconcileOrphansOnce(ids: string[]): Promise<string[]> {
+    if (this.didReconcileOrphans) {
+      return ids;
+    }
+    this.didReconcileOrphans = true;
+
+    const keys = (await this.storage.getAllKeys()).filter(isRecordStorageKey);
+    if (keys.length === 0) {
+      return ids;
+    }
+
+    const known = new Set(ids);
+    const merged = [...ids];
+    for (const key of keys) {
+      const id = key.slice(QUEUE_KEY_PREFIX.length);
+      if (!known.has(id)) {
+        known.add(id);
+        merged.push(id);
+      }
+    }
+
+    if (merged.length !== ids.length) {
+      await this.writeIndex(merged);
+    }
+    return merged;
   }
 
   private async writeIndex(ids: string[]): Promise<void> {
@@ -243,6 +301,8 @@ export class EventQueue {
   }
 
   private async persist(record: QueueRecord): Promise<void> {
+    // Record body first, then index: a crash mid-write may orphan the body, which
+    // {@link reconcileOrphansOnce} recovers. Index-first would lose the event entirely.
     await this.storage.setItem(recordStorageKey(record.id), JSON.stringify(record));
     const ids = await this.loadRecordIds();
     if (!ids.includes(record.id)) {
@@ -252,6 +312,8 @@ export class EventQueue {
   }
 
   private async remove(id: string): Promise<void> {
+    // Delete the body first so a crash before the index write cannot re-send a
+    // successfully delivered event. Phantom ids are pruned in {@link loadRecords}.
     await this.storage.removeItem(recordStorageKey(id));
     const ids = (await this.loadRecordIds()).filter((existing) => existing !== id);
     await this.writeIndex(ids);

--- a/packages/react-native/src/queue/event-queue.ts
+++ b/packages/react-native/src/queue/event-queue.ts
@@ -35,6 +35,8 @@ export class EventQueue {
   private readonly now: () => number;
   private readonly createId: () => string;
   private flushPromise: Promise<{ sent: number; remaining: number }> | null = null;
+  /** Serializes mutate paths so concurrent enqueues cannot bypass maxSize. */
+  private writeChain: Promise<unknown> = Promise.resolve();
 
   constructor(options: EventQueueOptions) {
     this.storage = options.storage;
@@ -52,24 +54,40 @@ export class EventQueue {
   }
 
   async enqueue(event: Event): Promise<QueueRecord> {
-    const records = await this.loadRecords();
-    await this.enforceCap(records);
+    return this.withWriteLock(async () => {
+      const records = await this.loadRecords();
+      await this.enforceCap(records);
 
-    if (this.dropPolicy === "newest" && records.length >= this.maxSize) {
-      // Cap full and dropping newest means reject this enqueue.
-      throw new Error("@topsort/react-native-sdk: offline queue is full (dropPolicy: newest)");
+      if (this.dropPolicy === "newest" && records.length >= this.maxSize) {
+        // Cap full and dropping newest means reject this enqueue.
+        throw new Error("@topsort/react-native-sdk: offline queue is full (dropPolicy: newest)");
+      }
+
+      const record: QueueRecord = {
+        id: this.createId(),
+        event,
+        enqueuedAt: new Date(this.now()).toISOString(),
+        attempts: 0,
+        nextAttemptAt: this.now(),
+      };
+
+      await this.persist(record);
+      return record;
+    });
+  }
+
+  private async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    const previous = this.writeChain;
+    let release!: () => void;
+    this.writeChain = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
     }
-
-    const record: QueueRecord = {
-      id: this.createId(),
-      event,
-      enqueuedAt: new Date(this.now()).toISOString(),
-      attempts: 0,
-      nextAttemptAt: this.now(),
-    };
-
-    await this.persist(record);
-    return record;
   }
 
   /** Flush due records oldest-first. Concurrent callers await the in-flight flush. */
@@ -85,11 +103,14 @@ export class EventQueue {
   }
 
   private async runFlush(): Promise<{ sent: number; remaining: number }> {
-    let sent = 0;
-    const records = (await this.loadRecords()).sort(
-      (a, b) => Date.parse(a.enqueuedAt) - Date.parse(b.enqueuedAt),
+    // Wait out in-flight enqueues, then snapshot under the write lock.
+    const records = await this.withWriteLock(async () =>
+      (await this.loadRecords()).sort(
+        (a, b) => Date.parse(a.enqueuedAt) - Date.parse(b.enqueuedAt),
+      ),
     );
     const now = this.now();
+    let sent = 0;
 
     for (const record of records) {
       if (record.nextAttemptAt > now) {
@@ -110,7 +131,7 @@ export class EventQueue {
       const result = await this.send(record.event);
 
       if (result.ok) {
-        await this.remove(record.id);
+        await this.withWriteLock(() => this.remove(record.id));
         return "sent";
       }
 
@@ -119,11 +140,11 @@ export class EventQueue {
       }
 
       // Non-retryable EventResult (should be rare) — drop like Android PERMANENT_FAILURE.
-      await this.remove(record.id);
+      await this.withWriteLock(() => this.remove(record.id));
       return "dropped";
     } catch (error) {
       if (isPermanentFailure(error)) {
-        await this.remove(record.id);
+        await this.withWriteLock(() => this.remove(record.id));
         return "dropped";
       }
       return await this.scheduleRetry(record);
@@ -133,7 +154,7 @@ export class EventQueue {
   private async scheduleRetry(record: QueueRecord): Promise<"retry" | "dropped"> {
     const attempts = record.attempts + 1;
     if (attempts >= this.maxAttempts) {
-      await this.remove(record.id);
+      await this.withWriteLock(() => this.remove(record.id));
       return "dropped";
     }
 
@@ -142,7 +163,7 @@ export class EventQueue {
       attempts,
       nextAttemptAt: nextAttemptAt(attempts, this.now()),
     };
-    await this.persist(updated);
+    await this.withWriteLock(() => this.persist(updated));
     return "retry";
   }
 

--- a/packages/react-native/src/queue/event-queue.ts
+++ b/packages/react-native/src/queue/event-queue.ts
@@ -237,10 +237,8 @@ export class EventQueue {
   }
 
   private async writeIndex(ids: string[]): Promise<void> {
-    if (ids.length === 0) {
-      await this.storage.removeItem(QUEUE_INDEX_KEY);
-      return;
-    }
+    // Always persist the index (including `[]`) so an empty queue does not fall
+    // back to getAllKeys() on every subsequent size()/enqueue/flush.
     await this.storage.setItem(QUEUE_INDEX_KEY, JSON.stringify(ids));
   }
 

--- a/packages/react-native/src/queue/flush-scheduler.ts
+++ b/packages/react-native/src/queue/flush-scheduler.ts
@@ -16,12 +16,17 @@ export class FlushScheduler {
   ) {}
 
   async start(): Promise<void> {
-    this.wasConnected = await this.connectivity.getIsConnected();
+    try {
+      this.wasConnected = await this.connectivity.getIsConnected();
+    } catch {
+      // Flaky NetInfo must not take down the client — assume online and continue.
+      this.wasConnected = true;
+    }
 
     this.unsubscribers.push(
       this.connectivity.subscribe((isConnected) => {
         if (isConnected && !this.wasConnected) {
-          void this.queue.flush();
+          this.safeFlush();
         }
         this.wasConnected = isConnected;
       }),
@@ -30,13 +35,17 @@ export class FlushScheduler {
     this.unsubscribers.push(
       this.appState.subscribe((state) => {
         if (state === "active" || state === "background") {
-          void this.queue.flush();
+          this.safeFlush();
         }
       }),
     );
 
     if (this.wasConnected) {
-      await this.queue.flush();
+      try {
+        await this.queue.flush();
+      } catch {
+        // Storage/read failures during startup must not reject `ready`.
+      }
     }
   }
 
@@ -45,5 +54,11 @@ export class FlushScheduler {
       unsubscribe();
     }
     this.unsubscribers.length = 0;
+  }
+
+  private safeFlush(): void {
+    void this.queue.flush().catch(() => {
+      // Background flushes must not surface as unhandled rejections.
+    });
   }
 }

--- a/packages/react-native/src/queue/flush-scheduler.ts
+++ b/packages/react-native/src/queue/flush-scheduler.ts
@@ -1,0 +1,49 @@
+import type { EventQueue } from "./event-queue";
+import type { AppStateSource, ConnectivitySource } from "./types";
+
+/**
+ * Flushes the durable queue on reconnect and AppState transitions
+ * (RN stand-in for Android WorkManager triggers).
+ */
+export class FlushScheduler {
+  private readonly unsubscribers: Array<() => void> = [];
+  private wasConnected = true;
+
+  constructor(
+    private readonly queue: EventQueue,
+    private readonly connectivity: ConnectivitySource,
+    private readonly appState: AppStateSource,
+  ) {}
+
+  async start(): Promise<void> {
+    this.wasConnected = await this.connectivity.getIsConnected();
+
+    this.unsubscribers.push(
+      this.connectivity.subscribe((isConnected) => {
+        if (isConnected && !this.wasConnected) {
+          void this.queue.flush();
+        }
+        this.wasConnected = isConnected;
+      }),
+    );
+
+    this.unsubscribers.push(
+      this.appState.subscribe((state) => {
+        if (state === "active" || state === "background") {
+          void this.queue.flush();
+        }
+      }),
+    );
+
+    if (this.wasConnected) {
+      await this.queue.flush();
+    }
+  }
+
+  stop(): void {
+    for (const unsubscribe of this.unsubscribers) {
+      unsubscribe();
+    }
+    this.unsubscribers.length = 0;
+  }
+}

--- a/packages/react-native/src/queue/index.ts
+++ b/packages/react-native/src/queue/index.ts
@@ -1,0 +1,17 @@
+export { nextAttemptAt, nextAttemptDelayMs } from "./backoff";
+export type { EventQueueOptions, SendEvent } from "./event-queue";
+export { EventQueue } from "./event-queue";
+export { FlushScheduler } from "./flush-scheduler";
+export { createDefaultAppStateSource, createDefaultConnectivitySource } from "./platform";
+export { createAsyncStorageAdapter } from "./storage/async-storage";
+export { createMemoryStorageAdapter, MemoryStorageAdapter } from "./storage/memory-storage";
+export type { MMKVStorageOptions } from "./storage/mmkv-storage";
+export { createMMKVStorageAdapter } from "./storage/mmkv-storage";
+export type {
+  AppStateSource,
+  ConnectivitySource,
+  DropPolicy,
+  EventStorageAdapter,
+  OfflineQueueOptions,
+  QueueRecord,
+} from "./types";

--- a/packages/react-native/src/queue/index.ts
+++ b/packages/react-native/src/queue/index.ts
@@ -15,3 +15,4 @@ export type {
   OfflineQueueOptions,
   QueueRecord,
 } from "./types";
+export { isRecordStorageKey, QUEUE_INDEX_KEY, QUEUE_KEY_PREFIX, recordStorageKey } from "./types";

--- a/packages/react-native/src/queue/platform.ts
+++ b/packages/react-native/src/queue/platform.ts
@@ -1,0 +1,59 @@
+import type { AppStateSource, ConnectivitySource } from "./types";
+
+/** Best-effort NetInfo connectivity source; always-connected if peer is missing. */
+export function createDefaultConnectivitySource(): ConnectivitySource {
+  try {
+    const NetInfo = require("@react-native-community/netinfo") as {
+      fetch: () => Promise<{ isConnected: boolean | null }>;
+      addEventListener: (listener: (state: { isConnected: boolean | null }) => void) => () => void;
+    };
+
+    return {
+      async getIsConnected() {
+        const state = await NetInfo.fetch();
+        return state.isConnected !== false;
+      },
+      subscribe(listener) {
+        return NetInfo.addEventListener((state) => {
+          listener(state.isConnected !== false);
+        });
+      },
+    };
+  } catch {
+    return {
+      async getIsConnected() {
+        return true;
+      },
+      subscribe() {
+        return () => {};
+      },
+    };
+  }
+}
+
+/** React Native AppState source; no-op outside RN. */
+export function createDefaultAppStateSource(): AppStateSource {
+  try {
+    const { AppState } = require("react-native") as {
+      AppState: {
+        addEventListener: (
+          type: string,
+          listener: (state: string) => void,
+        ) => { remove: () => void };
+      };
+    };
+
+    return {
+      subscribe(listener) {
+        const sub = AppState.addEventListener("change", listener);
+        return () => sub.remove();
+      },
+    };
+  } catch {
+    return {
+      subscribe() {
+        return () => {};
+      },
+    };
+  }
+}

--- a/packages/react-native/src/queue/storage/async-storage.ts
+++ b/packages/react-native/src/queue/storage/async-storage.ts
@@ -22,7 +22,13 @@ function loadAsyncStorage(): AsyncStorageLike {
   }
 }
 
-/** Default durable adapter (plaintext). Prefer {@link createMMKVStorageAdapter} for encryption. */
+/**
+ * Default durable adapter (plaintext). Prefer {@link createMMKVStorageAdapter} for encryption.
+ *
+ * Note: `EventQueue` maintains a dedicated record-id index so steady-state ops do not
+ * call `getAllKeys()` (which is O(all app keys) on AsyncStorage). `getAllKeys` is only
+ * used for a one-time migration when the index is missing.
+ */
 export function createAsyncStorageAdapter(): EventStorageAdapter {
   const storage = loadAsyncStorage();
   return {

--- a/packages/react-native/src/queue/storage/async-storage.ts
+++ b/packages/react-native/src/queue/storage/async-storage.ts
@@ -1,0 +1,34 @@
+import type { EventStorageAdapter } from "../types";
+
+type AsyncStorageLike = {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+  getAllKeys(): Promise<readonly string[]>;
+};
+
+function loadAsyncStorage(): AsyncStorageLike {
+  try {
+    // Lazy require keeps the peer optional for consumers who pass a custom adapter.
+    const mod = require("@react-native-async-storage/async-storage") as {
+      default: AsyncStorageLike;
+    };
+    return mod.default;
+  } catch {
+    throw new Error(
+      "@topsort/react-native-sdk: offlineQueue requires " +
+        "@react-native-async-storage/async-storage, or pass offlineQueue.storage.",
+    );
+  }
+}
+
+/** Default durable adapter (plaintext). Prefer {@link createMMKVStorageAdapter} for encryption. */
+export function createAsyncStorageAdapter(): EventStorageAdapter {
+  const storage = loadAsyncStorage();
+  return {
+    getItem: (key) => storage.getItem(key),
+    setItem: (key, value) => storage.setItem(key, value),
+    removeItem: (key) => storage.removeItem(key),
+    getAllKeys: async () => [...(await storage.getAllKeys())],
+  };
+}

--- a/packages/react-native/src/queue/storage/memory-storage.ts
+++ b/packages/react-native/src/queue/storage/memory-storage.ts
@@ -1,0 +1,26 @@
+import type { EventStorageAdapter } from "../types";
+
+/** In-memory adapter for tests and environments without AsyncStorage/MMKV. */
+export class MemoryStorageAdapter implements EventStorageAdapter {
+  private readonly store = new Map<string, string>();
+
+  async getItem(key: string): Promise<string | null> {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async removeItem(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async getAllKeys(): Promise<string[]> {
+    return [...this.store.keys()];
+  }
+}
+
+export function createMemoryStorageAdapter(): EventStorageAdapter {
+  return new MemoryStorageAdapter();
+}

--- a/packages/react-native/src/queue/storage/mmkv-storage.ts
+++ b/packages/react-native/src/queue/storage/mmkv-storage.ts
@@ -1,0 +1,58 @@
+import type { EventStorageAdapter } from "../types";
+
+type MMKVLike = {
+  getString(key: string): string | undefined;
+  set(key: string, value: string): void;
+  delete(key: string): void;
+  getAllKeys(): string[];
+};
+
+type MMKVConstructor = new (options?: { id?: string; encryptionKey?: string }) => MMKVLike;
+
+export interface MMKVStorageOptions {
+  /** MMKV instance id. Defaults to `"topsort-events"`. */
+  id?: string;
+  /**
+   * When set, uses MMKV's AES encryption — the practical analog of Android
+   * `EncryptedSharedPreferences`. Omit for plaintext MMKV.
+   */
+  encryptionKey?: string;
+}
+
+function loadMMKV(): MMKVConstructor {
+  try {
+    const mod = require("react-native-mmkv") as { MMKV: MMKVConstructor };
+    return mod.MMKV;
+  } catch {
+    throw new Error(
+      "@topsort/react-native-sdk: createMMKVStorageAdapter requires react-native-mmkv.",
+    );
+  }
+}
+
+/**
+ * Optional encrypted (or plaintext) MMKV-backed adapter.
+ * Prefer this over AsyncStorage when matching Android's encrypted-cache posture.
+ */
+export function createMMKVStorageAdapter(options: MMKVStorageOptions = {}): EventStorageAdapter {
+  const MMKV = loadMMKV();
+  const storage = new MMKV({
+    id: options.id ?? "topsort-events",
+    encryptionKey: options.encryptionKey,
+  });
+
+  return {
+    async getItem(key) {
+      return storage.getString(key) ?? null;
+    },
+    async setItem(key, value) {
+      storage.set(key, value);
+    },
+    async removeItem(key) {
+      storage.delete(key);
+    },
+    async getAllKeys() {
+      return storage.getAllKeys();
+    },
+  };
+}

--- a/packages/react-native/src/queue/types.ts
+++ b/packages/react-native/src/queue/types.ts
@@ -65,11 +65,13 @@ export interface QueueRecord {
 }
 
 export const QUEUE_KEY_PREFIX = "topsort.event.";
+/** JSON array of record ids — avoids scanning all AsyncStorage keys on each op. */
+export const QUEUE_INDEX_KEY = `${QUEUE_KEY_PREFIX}__index__`;
 
 export function recordStorageKey(id: string): string {
   return `${QUEUE_KEY_PREFIX}${id}`;
 }
 
 export function isRecordStorageKey(key: string): boolean {
-  return key.startsWith(QUEUE_KEY_PREFIX);
+  return key.startsWith(QUEUE_KEY_PREFIX) && key !== QUEUE_INDEX_KEY;
 }

--- a/packages/react-native/src/queue/types.ts
+++ b/packages/react-native/src/queue/types.ts
@@ -1,0 +1,75 @@
+import type { Event } from "@topsort/sdk-core";
+
+/** How to enforce {@link OfflineQueueOptions.maxSize}. */
+export type DropPolicy = "oldest" | "newest";
+
+/**
+ * Persistable storage for durable queue records.
+ * Keys are opaque record ids; values are JSON strings.
+ */
+export interface EventStorageAdapter {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+  getAllKeys(): Promise<string[]>;
+}
+
+/** Emits connectivity changes (RN: NetInfo). */
+export interface ConnectivitySource {
+  getIsConnected(): Promise<boolean>;
+  subscribe(listener: (isConnected: boolean) => void): () => void;
+}
+
+/** Emits app lifecycle transitions (RN: AppState). */
+export interface AppStateSource {
+  subscribe(listener: (state: string) => void): () => void;
+}
+
+export interface OfflineQueueOptions {
+  /**
+   * Persistent store for queued events. Defaults to AsyncStorage via
+   * {@link createAsyncStorageAdapter} when omitted.
+   */
+  storage?: EventStorageAdapter;
+  /**
+   * Maximum number of persisted records. Defaults to `1000`.
+   */
+  maxSize?: number;
+  /**
+   * Which record to drop when `maxSize` is exceeded. Defaults to `"oldest"`.
+   */
+  dropPolicy?: DropPolicy;
+  /**
+   * Max send attempts per record before dropping. Defaults to `10`.
+   */
+  maxAttempts?: number;
+  /**
+   * Optional connectivity source. Defaults to NetInfo when available.
+   * Pass a custom source in tests.
+   */
+  connectivity?: ConnectivitySource;
+  /**
+   * Optional AppState source. Defaults to React Native `AppState` when available.
+   * Pass a custom source in tests.
+   */
+  appState?: AppStateSource;
+}
+
+/** Persisted queue record (Android Cache record analog). */
+export interface QueueRecord {
+  id: string;
+  event: Event;
+  enqueuedAt: string;
+  attempts: number;
+  nextAttemptAt: number;
+}
+
+export const QUEUE_KEY_PREFIX = "topsort.event.";
+
+export function recordStorageKey(id: string): string {
+  return `${QUEUE_KEY_PREFIX}${id}`;
+}
+
+export function isRecordStorageKey(key: string): boolean {
+  return key.startsWith(QUEUE_KEY_PREFIX);
+}

--- a/packages/react-native/src/queue/types.ts
+++ b/packages/react-native/src/queue/types.ts
@@ -66,7 +66,7 @@ export interface QueueRecord {
 
 export const QUEUE_KEY_PREFIX = "topsort.event.";
 /** JSON array of record ids — avoids scanning all AsyncStorage keys on each op. */
-export const QUEUE_INDEX_KEY = `${QUEUE_KEY_PREFIX}__index__`;
+export const QUEUE_INDEX_KEY: string = `${QUEUE_KEY_PREFIX}__index__`;
 
 export function recordStorageKey(id: string): string {
   return `${QUEUE_KEY_PREFIX}${id}`;

--- a/packages/react-native/src/topsort-client.ts
+++ b/packages/react-native/src/topsort-client.ts
@@ -86,12 +86,14 @@ export class TopsortClient extends CoreTopsortClient {
     await this.ready;
 
     // Preserve durable FIFO: drain backlog before accepting a live send.
-    if ((await this.eventQueue.size()) > 0) {
-      const accepted = await this.acceptIntoQueue(event);
-      if (accepted.ok) {
+    // Size check + enqueue are one lock so a concurrent flush cannot TOCTOU us
+    // into unnecessarily queueing after the backlog has already drained.
+    const backlogAccepted = await this.acceptIntoQueueIfBacklog(event);
+    if (backlogAccepted) {
+      if (backlogAccepted.ok) {
         void this.eventQueue.flush().catch(() => {});
       }
-      return accepted;
+      return backlogAccepted;
     }
 
     try {
@@ -127,6 +129,24 @@ export class TopsortClient extends CoreTopsortClient {
       return { ok: false, retry: true };
     }
   }
+
+  /** @returns `null` when there was no backlog (caller should live-send). */
+  private async acceptIntoQueueIfBacklog(event: Event): Promise<EventResult | null> {
+    const queue = this.eventQueue;
+    if (!queue) {
+      return null;
+    }
+
+    try {
+      const record = await queue.enqueueIfBacklog(event);
+      if (!record) {
+        return null;
+      }
+      return { ok: true, retry: false };
+    } catch {
+      return { ok: false, retry: true };
+    }
+  }
 }
 
 function normalizeOfflineQueue(value: Config["offlineQueue"]): OfflineQueueOptions | null {
@@ -144,7 +164,9 @@ function normalizeOfflineQueue(value: Config["offlineQueue"]): OfflineQueueOptio
  * Matches Android Worker: network/transient → retry; 4xx → permanent (do not enqueue).
  *
  * Note: core maps HTTP 429/5xx to `{ ok: false, retry: true }` (not throws). Thrown
- * `AppError(500, …)` typically means a transport/network failure from api-client.
+ * `AppError(500, …)` typically means a transport/network failure from api-client, which
+ * already wraps non-AppError transport failures. Unknown throws are treated as transient
+ * (same as kt `catch (Exception)`), not programming-error surfaces from core.
  */
 function isEnqueueableFailure(error: unknown): boolean {
   if (!(error instanceof AppError)) {

--- a/packages/react-native/src/topsort-client.ts
+++ b/packages/react-native/src/topsort-client.ts
@@ -91,14 +91,30 @@ export class TopsortClient extends CoreTopsortClient {
       }
 
       // Core signal: retryable HTTP (429 / 5xx). Take ownership via durable queue.
-      await this.eventQueue.enqueue(event);
-      return { ok: true, retry: false };
+      return await this.acceptIntoQueue(event);
     } catch (error) {
-      if (isEnqueueableFailure(error)) {
-        await this.eventQueue.enqueue(event);
-        return { ok: true, retry: false };
+      if (!isEnqueueableFailure(error)) {
+        throw error;
       }
-      throw error;
+      return await this.acceptIntoQueue(event);
+    }
+  }
+
+  /**
+   * Persist a failed event. If the queue rejects (e.g. full + dropPolicy newest),
+   * surface the original retry contract instead of throwing a raw Error.
+   */
+  private async acceptIntoQueue(event: Event): Promise<EventResult> {
+    const queue = this.eventQueue;
+    if (!queue) {
+      return { ok: false, retry: true };
+    }
+
+    try {
+      await queue.enqueue(event);
+      return { ok: true, retry: false };
+    } catch {
+      return { ok: false, retry: true };
     }
   }
 }

--- a/packages/react-native/src/topsort-client.ts
+++ b/packages/react-native/src/topsort-client.ts
@@ -52,7 +52,8 @@ export class TopsortClient extends CoreTopsortClient {
       queueOptions.appState ?? createDefaultAppStateSource(),
     );
 
-    this.ready = this.flushScheduler.start();
+    // Startup must never take down reportEvent — degrade to direct send if wiring fails.
+    this.ready = this.flushScheduler.start().catch(() => {});
   }
 
   /**
@@ -83,6 +84,15 @@ export class TopsortClient extends CoreTopsortClient {
     }
 
     await this.ready;
+
+    // Preserve durable FIFO: drain backlog before accepting a live send.
+    if ((await this.eventQueue.size()) > 0) {
+      const accepted = await this.acceptIntoQueue(event);
+      if (accepted.ok) {
+        void this.eventQueue.flush().catch(() => {});
+      }
+      return accepted;
+    }
 
     try {
       const result = await super.reportEvent(event);

--- a/packages/react-native/src/topsort-client.ts
+++ b/packages/react-native/src/topsort-client.ts
@@ -1,14 +1,135 @@
-import { TopsortClient as CoreTopsortClient } from "@topsort/sdk-core";
+import {
+  AppError,
+  TopsortClient as CoreTopsortClient,
+  type Event,
+  type EventResult,
+} from "@topsort/sdk-core";
 import { version } from "../package.json";
+import {
+  createAsyncStorageAdapter,
+  createDefaultAppStateSource,
+  createDefaultConnectivitySource,
+  EventQueue,
+  FlushScheduler,
+  type OfflineQueueOptions,
+} from "./queue";
 import { rnTransport } from "./transport";
 import type { Config } from "./types";
 
+const DEFAULT_MAX_SIZE = 1000;
+const DEFAULT_MAX_ATTEMPTS = 10;
+
 export class TopsortClient extends CoreTopsortClient {
+  private readonly eventQueue: EventQueue | null = null;
+  private readonly flushScheduler: FlushScheduler | null = null;
+  private readonly ready: Promise<void>;
+
   constructor(config: Config) {
     super(config, {
       transport: rnTransport,
       sdkVersion: version,
       sdkPackageName: "@topsort/react-native-sdk",
     });
+
+    const queueOptions = normalizeOfflineQueue(config.offlineQueue);
+    if (!queueOptions) {
+      this.ready = Promise.resolve();
+      return;
+    }
+
+    const storage = queueOptions.storage ?? createAsyncStorageAdapter();
+    this.eventQueue = new EventQueue({
+      storage,
+      maxSize: queueOptions.maxSize ?? DEFAULT_MAX_SIZE,
+      dropPolicy: queueOptions.dropPolicy ?? "oldest",
+      maxAttempts: queueOptions.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      send: (event) => super.reportEvent(event),
+    });
+
+    this.flushScheduler = new FlushScheduler(
+      this.eventQueue,
+      queueOptions.connectivity ?? createDefaultConnectivitySource(),
+      queueOptions.appState ?? createDefaultAppStateSource(),
+    );
+
+    this.ready = this.flushScheduler.start();
   }
+
+  /**
+   * Wait until the offline queue has finished its initial flush wiring.
+   * No-op when the durable queue is disabled.
+   */
+  async whenReady(): Promise<void> {
+    await this.ready;
+  }
+
+  /** Manually flush persisted events (also runs on reconnect / AppState). */
+  async flush(): Promise<{ sent: number; remaining: number }> {
+    if (!this.eventQueue) {
+      return { sent: 0, remaining: 0 };
+    }
+    await this.ready;
+    return this.eventQueue.flush();
+  }
+
+  /** Stop AppState / connectivity listeners. Safe to call multiple times. */
+  dispose(): void {
+    this.flushScheduler?.stop();
+  }
+
+  override async reportEvent(event: Event): Promise<EventResult> {
+    if (!this.eventQueue) {
+      return super.reportEvent(event);
+    }
+
+    await this.ready;
+
+    try {
+      const result = await super.reportEvent(event);
+      if (result.ok || !result.retry) {
+        return result;
+      }
+
+      // Core signal: retryable HTTP (429 / 5xx). Take ownership via durable queue.
+      await this.eventQueue.enqueue(event);
+      return { ok: true, retry: false };
+    } catch (error) {
+      if (isEnqueueableFailure(error)) {
+        await this.eventQueue.enqueue(event);
+        return { ok: true, retry: false };
+      }
+      throw error;
+    }
+  }
+}
+
+function normalizeOfflineQueue(value: Config["offlineQueue"]): OfflineQueueOptions | null {
+  if (!value) {
+    return null;
+  }
+  if (value === true) {
+    return {};
+  }
+  return value;
+}
+
+/**
+ * Decide whether a thrown failure should be durably queued.
+ * Matches Android Worker: network/transient → retry; 4xx → permanent (do not enqueue).
+ *
+ * Note: core maps HTTP 429/5xx to `{ ok: false, retry: true }` (not throws). Thrown
+ * `AppError(500, …)` typically means a transport/network failure from api-client.
+ */
+function isEnqueueableFailure(error: unknown): boolean {
+  if (!(error instanceof AppError)) {
+    // Unknown thrown errors are treated as transient (same as kt catch Exception).
+    return true;
+  }
+  if (error.retry) {
+    return true;
+  }
+  if (error.status >= 400 && error.status < 500) {
+    return false;
+  }
+  return error.status >= 500;
 }

--- a/packages/react-native/src/types/index.ts
+++ b/packages/react-native/src/types/index.ts
@@ -1,6 +1,15 @@
 import type { Config as CoreConfig } from "@topsort/sdk-core";
+import type { OfflineQueueOptions } from "../queue/types";
 
 export type * from "@topsort/sdk-core";
+export type {
+  AppStateSource,
+  ConnectivitySource,
+  DropPolicy,
+  EventStorageAdapter,
+  OfflineQueueOptions,
+  QueueRecord,
+} from "../queue/types";
 
 /** React Native SDK config. */
 export interface Config extends Omit<CoreConfig, "fetchOptions"> {
@@ -9,4 +18,12 @@ export interface Config extends Omit<CoreConfig, "fetchOptions"> {
    * React Native (or compatible) typings that define it; this package does not ship DOM lib.
    */
   fetchOptions?: RequestInit;
+  /**
+   * Opt-in durable offline event queue (RN analog of web `keepalive`).
+   *
+   * When omitted / `false`, `reportEvent` matches Phase 2 / web-core semantics.
+   * When `true` or an options object, retryable and network failures are persisted
+   * and flushed on reconnect / AppState transitions.
+   */
+  offlineQueue?: boolean | OfflineQueueOptions;
 }

--- a/packages/react-native/test/events-offline.test.ts
+++ b/packages/react-native/test/events-offline.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { AppError, baseURL, type Event, endpoints } from "@topsort/sdk-core";
+import { TopsortClient } from "../src";
+import { mswServer, returnError, returnStatus } from "../src/constants/handlers.constant";
+import {
+  type AppStateSource,
+  type ConnectivitySource,
+  createMemoryStorageAdapter,
+} from "../src/queue";
+
+const sampleEvent: Event = {
+  impressions: [
+    {
+      id: "imp-offline-1",
+      occurredAt: "2024-10-31T12:00:00Z",
+      opaqueUserId: "user-1",
+      resolvedBidId: "bid-1",
+    },
+  ],
+};
+
+function createConnectivityMock(initial = true): ConnectivitySource & {
+  setConnected: (value: boolean) => void;
+} {
+  let connected = initial;
+  const listeners = new Set<(value: boolean) => void>();
+  return {
+    async getIsConnected() {
+      return connected;
+    },
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    setConnected(value: boolean) {
+      connected = value;
+      for (const listener of listeners) {
+        listener(value);
+      }
+    },
+  };
+}
+
+function createAppStateMock(): AppStateSource & { emit: (state: string) => void } {
+  const listeners = new Set<(state: string) => void>();
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emit(state: string) {
+      for (const listener of listeners) {
+        listener(state);
+      }
+    },
+  };
+}
+
+describe("reportEvent with offlineQueue", () => {
+  let storage: ReturnType<typeof createMemoryStorageAdapter>;
+  let connectivity: ReturnType<typeof createConnectivityMock>;
+  let appState: ReturnType<typeof createAppStateMock>;
+  let client: TopsortClient;
+
+  beforeAll(() => mswServer.listen());
+  afterEach(() => {
+    client?.dispose();
+    mswServer.resetHandlers();
+  });
+  beforeEach(async () => {
+    storage = createMemoryStorageAdapter();
+    connectivity = createConnectivityMock(true);
+    appState = createAppStateMock();
+    client = new TopsortClient({
+      apiKey: "apiKey",
+      offlineQueue: {
+        storage,
+        connectivity,
+        appState,
+        maxSize: 50,
+        maxAttempts: 5,
+      },
+    });
+    await client.whenReady();
+  });
+
+  it("enqueues retryable HTTP failures and returns ok after accept", async () => {
+    returnStatus(429, `${baseURL}/${endpoints.events}`);
+
+    await expect(client.reportEvent(sampleEvent)).resolves.toEqual({
+      ok: true,
+      retry: false,
+    });
+    expect(await storage.getAllKeys()).toHaveLength(1);
+  });
+
+  it("enqueues transport/network failures", async () => {
+    returnError(`${baseURL}/${endpoints.events}`);
+
+    await expect(client.reportEvent(sampleEvent)).resolves.toEqual({
+      ok: true,
+      retry: false,
+    });
+    expect(await storage.getAllKeys()).toHaveLength(1);
+  });
+
+  it("does not enqueue permanent 4xx failures", async () => {
+    returnStatus(401, `${baseURL}/${endpoints.events}`);
+
+    await expect(client.reportEvent(sampleEvent)).rejects.toEqual({
+      status: 401,
+      retry: false,
+      statusText: "Unauthorized",
+      body: {},
+    });
+    expect(await storage.getAllKeys()).toHaveLength(0);
+  });
+
+  it("flushes queued events when connectivity is restored", async () => {
+    connectivity.setConnected(false);
+    returnError(`${baseURL}/${endpoints.events}`);
+
+    await client.reportEvent(sampleEvent);
+    expect(await storage.getAllKeys()).toHaveLength(1);
+
+    mswServer.resetHandlers();
+    returnStatus(204, `${baseURL}/${endpoints.events}`);
+    connectivity.setConnected(true);
+
+    // Allow the async flush triggered by connectivity to settle.
+    await Bun.sleep(10);
+    await client.flush();
+
+    expect(await storage.getAllKeys()).toHaveLength(0);
+  });
+
+  it("flushes on AppState active/background transitions", async () => {
+    returnError(`${baseURL}/${endpoints.events}`);
+    await client.reportEvent(sampleEvent);
+
+    mswServer.resetHandlers();
+    returnStatus(204, `${baseURL}/${endpoints.events}`);
+    appState.emit("background");
+    await Bun.sleep(10);
+    await client.flush();
+
+    expect(await storage.getAllKeys()).toHaveLength(0);
+  });
+
+  it("survives a simulated app restart via the shared storage adapter", async () => {
+    returnError(`${baseURL}/${endpoints.events}`);
+    await client.reportEvent(sampleEvent);
+    client.dispose();
+
+    mswServer.resetHandlers();
+    returnStatus(204, `${baseURL}/${endpoints.events}`);
+
+    const restarted = new TopsortClient({
+      apiKey: "apiKey",
+      offlineQueue: {
+        storage,
+        connectivity: createConnectivityMock(true),
+        appState: createAppStateMock(),
+      },
+    });
+    await restarted.whenReady();
+    await restarted.flush();
+
+    expect(await storage.getAllKeys()).toHaveLength(0);
+    restarted.dispose();
+  });
+
+  it("keeps Phase 2 semantics when offlineQueue is disabled", async () => {
+    const plain = new TopsortClient({ apiKey: "apiKey" });
+    returnStatus(429, `${baseURL}/${endpoints.events}`);
+    await expect(plain.reportEvent(sampleEvent)).resolves.toEqual({
+      ok: false,
+      retry: true,
+    });
+
+    returnError(`${baseURL}/${endpoints.events}`);
+    await expect(plain.reportEvent(sampleEvent)).rejects.toBeInstanceOf(AppError);
+  });
+});

--- a/packages/react-native/test/events-offline.test.ts
+++ b/packages/react-native/test/events-offline.test.ts
@@ -6,6 +6,7 @@ import {
   type AppStateSource,
   type ConnectivitySource,
   createMemoryStorageAdapter,
+  isRecordStorageKey,
 } from "../src/queue";
 
 const sampleEvent: Event = {
@@ -56,6 +57,12 @@ function createAppStateMock(): AppStateSource & { emit: (state: string) => void 
   };
 }
 
+async function queuedRecordCount(
+  adapter: ReturnType<typeof createMemoryStorageAdapter>,
+): Promise<number> {
+  return (await adapter.getAllKeys()).filter(isRecordStorageKey).length;
+}
+
 describe("reportEvent with offlineQueue", () => {
   let storage: ReturnType<typeof createMemoryStorageAdapter>;
   let connectivity: ReturnType<typeof createConnectivityMock>;
@@ -91,7 +98,7 @@ describe("reportEvent with offlineQueue", () => {
       ok: true,
       retry: false,
     });
-    expect(await storage.getAllKeys()).toHaveLength(1);
+    expect(await queuedRecordCount(storage)).toBe(1);
   });
 
   it("enqueues transport/network failures", async () => {
@@ -101,7 +108,7 @@ describe("reportEvent with offlineQueue", () => {
       ok: true,
       retry: false,
     });
-    expect(await storage.getAllKeys()).toHaveLength(1);
+    expect(await queuedRecordCount(storage)).toBe(1);
   });
 
   it("does not enqueue permanent 4xx failures", async () => {
@@ -121,7 +128,7 @@ describe("reportEvent with offlineQueue", () => {
     returnError(`${baseURL}/${endpoints.events}`);
 
     await client.reportEvent(sampleEvent);
-    expect(await storage.getAllKeys()).toHaveLength(1);
+    expect(await queuedRecordCount(storage)).toBe(1);
 
     mswServer.resetHandlers();
     returnStatus(204, `${baseURL}/${endpoints.events}`);
@@ -203,13 +210,115 @@ describe("reportEvent with offlineQueue", () => {
       ok: true,
       retry: false,
     });
-    expect(await fullStorage.getAllKeys()).toHaveLength(1);
+    expect(await queuedRecordCount(fullStorage)).toBe(1);
 
     // Queue is full; rejecting newest must not throw a raw Error through reportEvent.
     await expect(client.reportEvent(sampleEvent)).resolves.toEqual({
       ok: false,
       retry: true,
     });
-    expect(await fullStorage.getAllKeys()).toHaveLength(1);
+    expect(await queuedRecordCount(fullStorage)).toBe(1);
+  });
+
+  it("still reports events when connectivity startup rejects", async () => {
+    client.dispose();
+    const flakyConnectivity: ConnectivitySource = {
+      async getIsConnected() {
+        throw new Error("NetInfo unavailable");
+      },
+      subscribe() {
+        return () => {};
+      },
+    };
+
+    client = new TopsortClient({
+      apiKey: "apiKey",
+      offlineQueue: {
+        storage: createMemoryStorageAdapter(),
+        connectivity: flakyConnectivity,
+        appState: createAppStateMock(),
+      },
+    });
+
+    returnStatus(204, `${baseURL}/${endpoints.events}`);
+    await expect(client.reportEvent(sampleEvent)).resolves.toEqual({
+      ok: true,
+      retry: false,
+    });
+  });
+
+  it("preserves FIFO when backlog exists before a live send", async () => {
+    const { HttpResponse, http } = await import("msw");
+    client.dispose();
+
+    connectivity = createConnectivityMock(false);
+    storage = createMemoryStorageAdapter();
+    client = new TopsortClient({
+      apiKey: "apiKey",
+      offlineQueue: {
+        storage,
+        connectivity,
+        appState: createAppStateMock(),
+        maxAttempts: 5,
+      },
+    });
+    await client.whenReady();
+
+    const eventA: Event = {
+      impressions: [
+        {
+          id: "imp-a",
+          occurredAt: "2024-10-31T12:00:00Z",
+          opaqueUserId: "user-1",
+          resolvedBidId: "bid-1",
+        },
+      ],
+    };
+    const eventB: Event = {
+      impressions: [
+        {
+          id: "imp-b",
+          occurredAt: "2024-10-31T12:00:01Z",
+          opaqueUserId: "user-1",
+          resolvedBidId: "bid-1",
+        },
+      ],
+    };
+    const eventC: Event = {
+      impressions: [
+        {
+          id: "imp-c",
+          occurredAt: "2024-10-31T12:00:02Z",
+          opaqueUserId: "user-1",
+          resolvedBidId: "bid-1",
+        },
+      ],
+    };
+
+    returnError(`${baseURL}/${endpoints.events}`);
+    await client.reportEvent(eventA);
+    await client.reportEvent(eventB);
+
+    const sentIds: string[] = [];
+    mswServer.resetHandlers();
+    mswServer.use(
+      http.post(`${baseURL}/${endpoints.events}`, async ({ request }) => {
+        const body = (await request.json()) as Event;
+        const id = body.impressions?.[0]?.id;
+        if (id) {
+          sentIds.push(id);
+        }
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    // Still offline with backlog — C must enqueue behind A/B, not jump the line.
+    await client.reportEvent(eventC);
+    connectivity.setConnected(true);
+    await Bun.sleep(10);
+    await client.flush();
+
+    expect(sentIds).toEqual(["imp-a", "imp-b", "imp-c"]);
+    expect(await storage.getAllKeys()).toHaveLength(0);
   });
 });

--- a/packages/react-native/test/events-offline.test.ts
+++ b/packages/react-native/test/events-offline.test.ts
@@ -120,7 +120,7 @@ describe("reportEvent with offlineQueue", () => {
       statusText: "Unauthorized",
       body: {},
     });
-    expect(await storage.getAllKeys()).toHaveLength(0);
+    expect(await queuedRecordCount(storage)).toBe(0);
   });
 
   it("flushes queued events when connectivity is restored", async () => {
@@ -138,7 +138,7 @@ describe("reportEvent with offlineQueue", () => {
     await Bun.sleep(10);
     await client.flush();
 
-    expect(await storage.getAllKeys()).toHaveLength(0);
+    expect(await queuedRecordCount(storage)).toBe(0);
   });
 
   it("flushes on AppState active/background transitions", async () => {
@@ -151,7 +151,7 @@ describe("reportEvent with offlineQueue", () => {
     await Bun.sleep(10);
     await client.flush();
 
-    expect(await storage.getAllKeys()).toHaveLength(0);
+    expect(await queuedRecordCount(storage)).toBe(0);
   });
 
   it("survives a simulated app restart via the shared storage adapter", async () => {
@@ -173,7 +173,7 @@ describe("reportEvent with offlineQueue", () => {
     await restarted.whenReady();
     await restarted.flush();
 
-    expect(await storage.getAllKeys()).toHaveLength(0);
+    expect(await queuedRecordCount(storage)).toBe(0);
     restarted.dispose();
   });
 
@@ -319,6 +319,6 @@ describe("reportEvent with offlineQueue", () => {
     await client.flush();
 
     expect(sentIds).toEqual(["imp-a", "imp-b", "imp-c"]);
-    expect(await storage.getAllKeys()).toHaveLength(0);
+    expect(await queuedRecordCount(storage)).toBe(0);
   });
 });

--- a/packages/react-native/test/events-offline.test.ts
+++ b/packages/react-native/test/events-offline.test.ts
@@ -181,4 +181,35 @@ describe("reportEvent with offlineQueue", () => {
     returnError(`${baseURL}/${endpoints.events}`);
     await expect(plain.reportEvent(sampleEvent)).rejects.toBeInstanceOf(AppError);
   });
+
+  it("returns retryable result when newest dropPolicy rejects a full queue", async () => {
+    client.dispose();
+    const fullStorage = createMemoryStorageAdapter();
+    client = new TopsortClient({
+      apiKey: "apiKey",
+      offlineQueue: {
+        storage: fullStorage,
+        connectivity: createConnectivityMock(true),
+        appState: createAppStateMock(),
+        maxSize: 1,
+        dropPolicy: "newest",
+        maxAttempts: 5,
+      },
+    });
+    await client.whenReady();
+
+    returnStatus(429, `${baseURL}/${endpoints.events}`);
+    await expect(client.reportEvent(sampleEvent)).resolves.toEqual({
+      ok: true,
+      retry: false,
+    });
+    expect(await fullStorage.getAllKeys()).toHaveLength(1);
+
+    // Queue is full; rejecting newest must not throw a raw Error through reportEvent.
+    await expect(client.reportEvent(sampleEvent)).resolves.toEqual({
+      ok: false,
+      retry: true,
+    });
+    expect(await fullStorage.getAllKeys()).toHaveLength(1);
+  });
 });

--- a/packages/react-native/test/queue.test.ts
+++ b/packages/react-native/test/queue.test.ts
@@ -267,4 +267,86 @@ describe("EventQueue", () => {
     expect(await storage.getItem("topsort.event.__index__")).toBe(JSON.stringify(["rec-1"]));
     expect(await storage.getItem("topsort.event.rec-1")).not.toBeNull();
   });
+
+  it("prunes phantom index entries left by a crash mid-remove", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.setItem("topsort.event.__index__", JSON.stringify(["gone", "alive"]));
+    await storage.setItem(
+      "topsort.event.alive",
+      JSON.stringify({
+        id: "alive",
+        event: sampleEvent,
+        enqueuedAt: "2024-10-31T12:00:00.000Z",
+        attempts: 0,
+        nextAttemptAt: 0,
+      }),
+    );
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: true, retry: false }),
+    });
+
+    expect(await queue.size()).toBe(1);
+    expect(await storage.getItem("topsort.event.__index__")).toBe(JSON.stringify(["alive"]));
+
+    await queue.flush();
+    expect(await queue.size()).toBe(0);
+    expect(await storage.getItem("topsort.event.__index__")).toBe("[]");
+  });
+
+  it("recovers orphan record bodies missing from the index", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.setItem("topsort.event.__index__", "[]");
+    await storage.setItem(
+      "topsort.event.orphan-1",
+      JSON.stringify({
+        id: "orphan-1",
+        event: sampleEvent,
+        enqueuedAt: "2024-10-31T12:00:00.000Z",
+        attempts: 0,
+        nextAttemptAt: 0,
+      }),
+    );
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: true, retry: false }),
+    });
+
+    expect(await queue.size()).toBe(1);
+    expect(await storage.getItem("topsort.event.__index__")).toBe(JSON.stringify(["orphan-1"]));
+
+    const result = await queue.flush();
+    expect(result).toEqual({ sent: 1, remaining: 0 });
+  });
+
+  it("enqueueIfBacklog is a no-op when the queue is empty", async () => {
+    const storage = createMemoryStorageAdapter();
+    let id = 0;
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: true, retry: false }),
+      createId: () => {
+        id += 1;
+        return `rec-${id}`;
+      },
+    });
+
+    expect(await queue.enqueueIfBacklog(sampleEvent)).toBeNull();
+    expect(await queue.size()).toBe(0);
+
+    await queue.enqueue(sampleEvent);
+    expect(await queue.enqueueIfBacklog(sampleEvent)).not.toBeNull();
+    expect(await queue.size()).toBe(2);
+  });
 });

--- a/packages/react-native/test/queue.test.ts
+++ b/packages/react-native/test/queue.test.ts
@@ -188,6 +188,38 @@ describe("EventQueue", () => {
 
     await queue.flush();
     expect(await queue.size()).toBe(0);
+    expect(await storage.getItem("topsort.event.__index__")).toBe("[]");
+  });
+
+  it("keeps an empty index so size() does not rescan storage after flush", async () => {
+    const base = createMemoryStorageAdapter();
+    let getAllKeysCalls = 0;
+    const storage = {
+      getItem: (key: string) => base.getItem(key),
+      setItem: (key: string, value: string) => base.setItem(key, value),
+      removeItem: (key: string) => base.removeItem(key),
+      getAllKeys: async () => {
+        getAllKeysCalls += 1;
+        return base.getAllKeys();
+      },
+    };
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: true, retry: false }),
+      createId: () => "rec-1",
+    });
+
+    await queue.enqueue(sampleEvent);
+    await queue.flush();
+    const callsAfterFlush = getAllKeysCalls;
+
+    expect(await queue.size()).toBe(0);
+    expect(await storage.getItem("topsort.event.__index__")).toBe("[]");
+    expect(getAllKeysCalls).toBe(callsAfterFlush);
   });
 
   it("keeps the index consistent when size() races with enqueue on first launch", async () => {

--- a/packages/react-native/test/queue.test.ts
+++ b/packages/react-native/test/queue.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import type { Event, EventResult } from "@topsort/sdk-core";
+import { AppError } from "@topsort/sdk-core";
+import { createMemoryStorageAdapter, EventQueue } from "../src/queue";
+
+const sampleEvent: Event = {
+  impressions: [
+    {
+      id: "imp-1",
+      occurredAt: "2024-10-31T12:00:00Z",
+      opaqueUserId: "user-1",
+      resolvedBidId: "bid-1",
+    },
+  ],
+};
+
+describe("EventQueue", () => {
+  it("persists across a new queue instance (simulated app restart)", async () => {
+    const storage = createMemoryStorageAdapter();
+    let sends = 0;
+
+    const first = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => {
+        sends += 1;
+        return { ok: true, retry: false };
+      },
+      now: () => 1_000,
+      createId: () => "rec-1",
+    });
+
+    await first.enqueue(sampleEvent);
+    expect(await first.size()).toBe(1);
+
+    const restarted = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => {
+        sends += 1;
+        return { ok: true, retry: false };
+      },
+    });
+
+    expect(await restarted.size()).toBe(1);
+    const result = await restarted.flush();
+    expect(result).toEqual({ sent: 1, remaining: 0 });
+    expect(sends).toBe(1);
+  });
+
+  it("retries on { ok: false, retry: true } and drops after maxAttempts", async () => {
+    const storage = createMemoryStorageAdapter();
+    let calls = 0;
+    let clock = 0;
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 3,
+      send: async (): Promise<EventResult> => {
+        calls += 1;
+        return { ok: false, retry: true };
+      },
+      now: () => clock,
+      createId: () => "rec-retry",
+    });
+
+    await queue.enqueue(sampleEvent);
+
+    for (let i = 0; i < 3; i += 1) {
+      clock += 60_000;
+      await queue.flush();
+    }
+
+    expect(calls).toBe(3);
+    expect(await queue.size()).toBe(0);
+  });
+
+  it("drops permanent 4xx failures without retrying forever", async () => {
+    const storage = createMemoryStorageAdapter();
+    let calls = 0;
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 10,
+      send: async () => {
+        calls += 1;
+        throw new AppError(401, "Unauthorized", {}, false);
+      },
+      createId: () => "rec-perm",
+    });
+
+    await queue.enqueue(sampleEvent);
+    await queue.flush();
+
+    expect(calls).toBe(1);
+    expect(await queue.size()).toBe(0);
+  });
+
+  it("drops oldest records when the queue cap is reached", async () => {
+    const storage = createMemoryStorageAdapter();
+    let id = 0;
+    let clock = 0;
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 2,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: false, retry: true }),
+      now: () => {
+        clock += 1;
+        return clock;
+      },
+      createId: () => {
+        id += 1;
+        return `rec-${id}`;
+      },
+    });
+
+    await queue.enqueue(sampleEvent);
+    await queue.enqueue(sampleEvent);
+    await queue.enqueue(sampleEvent);
+
+    expect(await queue.size()).toBe(2);
+    const keys = await storage.getAllKeys();
+    expect(keys.some((key) => key.endsWith("rec-1"))).toBe(false);
+    expect(keys.some((key) => key.endsWith("rec-2"))).toBe(true);
+    expect(keys.some((key) => key.endsWith("rec-3"))).toBe(true);
+  });
+});

--- a/packages/react-native/test/queue.test.ts
+++ b/packages/react-native/test/queue.test.ts
@@ -135,4 +135,30 @@ describe("EventQueue", () => {
     expect(keys.some((key) => key.endsWith("rec-2"))).toBe(true);
     expect(keys.some((key) => key.endsWith("rec-3"))).toBe(true);
   });
+
+  it("respects maxSize under concurrent enqueue", async () => {
+    const storage = createMemoryStorageAdapter();
+    let id = 0;
+    let clock = 0;
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 3,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: false, retry: true }),
+      now: () => {
+        clock += 1;
+        return clock;
+      },
+      createId: () => {
+        id += 1;
+        return `rec-${id}`;
+      },
+    });
+
+    await Promise.all(Array.from({ length: 10 }, () => queue.enqueue(sampleEvent)));
+
+    expect(await queue.size()).toBe(3);
+  });
 });

--- a/packages/react-native/test/queue.test.ts
+++ b/packages/react-native/test/queue.test.ts
@@ -189,4 +189,50 @@ describe("EventQueue", () => {
     await queue.flush();
     expect(await queue.size()).toBe(0);
   });
+
+  it("keeps the index consistent when size() races with enqueue on first launch", async () => {
+    const base = createMemoryStorageAdapter();
+    let releaseGetAllKeys!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGetAllKeys = resolve;
+    });
+    let blockedOnce = false;
+
+    const storage = {
+      getItem: (key: string) => base.getItem(key),
+      setItem: (key: string, value: string) => base.setItem(key, value),
+      removeItem: (key: string) => base.removeItem(key),
+      getAllKeys: async () => {
+        if (!blockedOnce) {
+          blockedOnce = true;
+          await gate;
+        }
+        return base.getAllKeys();
+      },
+    };
+
+    let id = 0;
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: false, retry: true }),
+      createId: () => {
+        id += 1;
+        return `rec-${id}`;
+      },
+    });
+
+    // size() starts unlocked-looking migration; write lock must serialize enqueue behind it.
+    const sizePromise = queue.size();
+    await Bun.sleep(5);
+    const enqueuePromise = queue.enqueue(sampleEvent);
+    releaseGetAllKeys();
+    await Promise.all([sizePromise, enqueuePromise]);
+
+    expect(await queue.size()).toBe(1);
+    expect(await storage.getItem("topsort.event.__index__")).toBe(JSON.stringify(["rec-1"]));
+    expect(await storage.getItem("topsort.event.rec-1")).not.toBeNull();
+  });
 });

--- a/packages/react-native/test/queue.test.ts
+++ b/packages/react-native/test/queue.test.ts
@@ -161,4 +161,32 @@ describe("EventQueue", () => {
 
     expect(await queue.size()).toBe(3);
   });
+
+  it("migrates legacy records into the index on first load", async () => {
+    const storage = createMemoryStorageAdapter();
+    await storage.setItem(
+      "topsort.event.legacy-1",
+      JSON.stringify({
+        id: "legacy-1",
+        event: sampleEvent,
+        enqueuedAt: "2024-10-31T12:00:00.000Z",
+        attempts: 0,
+        nextAttemptAt: 0,
+      }),
+    );
+
+    const queue = new EventQueue({
+      storage,
+      maxSize: 10,
+      dropPolicy: "oldest",
+      maxAttempts: 5,
+      send: async () => ({ ok: true, retry: false }),
+    });
+
+    expect(await queue.size()).toBe(1);
+    expect(await storage.getItem("topsort.event.__index__")).toBe(JSON.stringify(["legacy-1"]));
+
+    await queue.flush();
+    expect(await queue.size()).toBe(0);
+  });
 });


### PR DESCRIPTION
**Resolves:** https://topsort.atlassian.net/browse/INTE-2605

## Summary
- add an opt-in durable React Native event queue with bounded retries, exponential backoff, and configurable capacity/drop policy
- flush queued events on reconnect and React Native AppState transitions
- provide AsyncStorage, memory, and optional encrypted MMKV storage adapters while preserving existing behavior when the queue is disabled
- document the API and bump only the React Native package to 0.5.0

## Test plan
- [x] `bun run format`
- [x] `bun run typecheck`
- [x] `bun run test -- --coverage --coverage-reporter=lcov --coverage-dir=coverage`
- [x] React Native build and harness
- [x] Web build

**Reviewers:** @barbmarcio 